### PR TITLE
wrong field name for Composition context

### DIFF
--- a/ImplementationGuide/markdown/BerichtSubsystem/BerichtSubsystem_AnmerkungenZuDenMustSupportFeldern.md
+++ b/ImplementationGuide/markdown/BerichtSubsystem/BerichtSubsystem_AnmerkungenZuDenMustSupportFeldern.md
@@ -63,7 +63,7 @@ Beispiel:
 
 **Bedeutung:** Patientenbezug des Dokumentes
 
-### `Composition.context`
+### `Composition.encounter`
 
 **Bedeutung:** Fallbezug des Dokumentes
 


### PR DESCRIPTION
Das Feld context gibt's bei Composition nicht. Der Beschreibung nach ist eher encounter gemeint.
cf. https://simplifier.net/guide/Implementierungsleitfaden-ISiK-Basismodul-Stufe-3/ImplementationGuide-markdown-Datenobjekte-Datenobjekte-BerichtSubsystem?version=current