### PR TITLE
Fix DiagnosesSCT ValueSet definition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
     branches:
     - 'main**'
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 

--- a/ImplementationGuide/markdown/Binary/Binary_Motivation.md
+++ b/ImplementationGuide/markdown/Binary/Binary_Motivation.md
@@ -7,6 +7,6 @@ Binary-Ressourcen werden von Attachment-Elementen verlinkt und damit in den Kont
 (z.B. Patient und Encounter) gestellt.
 
 Das ISIK-Binary-Profil ist *nicht* Bestandteil der Implementierung des ISIK Basismoduls.
-Das Profil ist Teil des ISIK Basismoduls, da es als übergreifend genutzte Ressource sowohl im [Modul Terminplanung](https://simplifier.net/guide/Implementierungsleitfaden-ISiK-Modul-Terminplanung-Stufe-3/ImplementationGuide-markdown-Datenobjekte?version=current) als auch im [Modul Dokumentenaustausch](https://simplifier.net/guide/Implementierungsleitfaden-ISiK-Modul-Dokumentenaustausch-Stufe-3/ImplementationGuide-markdown-Datenobjekte?version=current) implementiert werden muss.  
+Das Profil ist Teil des ISIK Basismoduls, da es als übergreifend genutzte Ressource sowohl im [Modul Terminplanung](https://simplifier.net/guide/isik-terminplanung-v3/ImplementationGuide-markdown-Datenobjekte?version=current) als auch im [Modul Dokumentenaustausch](https://simplifier.net/guide/isik-dokumentenaustausch-v3/ImplementationGuide-markdown-Datenobjekte?version=current) implementiert werden muss.  
 
 ---

--- a/ImplementationGuide/markdown/Versicherungsverhaeltnis/Versicherungsverhaeltnis_AnmerkungenZuDenMustSupportFeldern.md
+++ b/ImplementationGuide/markdown/Versicherungsverhaeltnis/Versicherungsverhaeltnis_AnmerkungenZuDenMustSupportFeldern.md
@@ -4,7 +4,7 @@
 
 ### `Coverage.identifier`
 
-**Hinweise:** Grundsätzlich ist zu beachten, dass das Versicherungsverhältnis für die gesetzliche Versicherung durch die 30-stellige KVNR identifiziert wird. Die 10-stellige KVNR ist hingegen ein Identifier für das Datenobjekt Patient. Siehe {{pagelink:ImplementationGuide/markdown/Patient_Profil.md, text:Datenobjekt - Patient}}. Es wird in ISiK davon ausgegangen, dass die 30-stellige KVNR nicht in bestätigungrelevanten Systemen geführt wird, sodass diese nicht als zuverlässiger Identifier für das Versicherungsverhältnis verwendbar ist. Bei einer Suche nach einem Versicherungsverhältnis SOLLTE dieses per Chaining auf das Datenobjekt Patient ermittelt werden.
+**Hinweise:** Grundsätzlich ist zu beachten, dass das Versicherungsverhältnis für die gesetzliche Versicherung durch die 30-stellige KVNR identifiziert wird. Die 10-stellige KVNR (gemeint ist der unveränderbare 10-stellige Teil zur Identifikation der Versicherten [laut ITSG](https://www.itsg.de/produkte/vst-krankenversichertennummer)) ist hingegen ein Identifier für das Datenobjekt 'Patient'. Siehe {{pagelink:ImplementationGuide/markdown/Patient/Patient_Profil.md, text:Datenobjekt - Patient}}. Es wird in ISiK davon ausgegangen, dass die 30-stellige KVNR nicht in bestätigungrelevanten Systemen geführt wird, sodass diese nicht als zuverlässiger Identifier für das Versicherungsverhältnis verwendbar ist. Bei einer Suche nach einem Versicherungsverhältnis SOLLTE dieses per Chaining auf das Datenobjekt Patient ermittelt werden.
 
 ### `Coverage.status`
 

--- a/Resources/input/fsh/valueSets.fsh
+++ b/Resources/input/fsh/valueSets.fsh
@@ -3,9 +3,11 @@ Id: DiagnosesSCT
 Description: "Enthaelt alle SNOMED Clinical finding, Event und Situation with explicit context codes"
 * insert Meta
 * include codes from system SNOMED_CT
-    where concept is-a #404684003 and
-    concept is-a #272379006 and
-    concept is-a #243796009
+    where concept is-a #404684003
+* include codes from system SNOMED_CT
+    where concept is-a #272379006
+* include codes from system SNOMED_CT
+    where concept is-a #243796009
 
 ValueSet: ProzedurenCodesSCT
 Id: ProzedurenCodesSCT


### PR DESCRIPTION
# Contributor Pull Request
Fix DiagnosesSCT ValueSet definition

## Description
Fix the DiagnosesSCT ValueSet definition: the initial include statement has been split into three separate include statements.

## Motivation and Context
It appears there is a bug due to all the filters sitting beneath one include statement. Multiple filters in the same include statement assume a logical AND evaluation, and obviously, there's no concept that contains all three of these concepts in their ancestor chain.

## How has this been tested?
Initial ValueSet definition expansion returns nothing:
https://r4.ontoserver.csiro.au/fhir/ValueSet/32367c12-3e08-46a4-bfc9-c84b9849efb9/$expand

Updated ValueSet definition expansion returns concepts:
https://r4.ontoserver.csiro.au/fhir/ValueSet/de18023b-0d33-4ad1-a5d1-dae1f02d3dc7/$expand

## Snippets or Screenshots (if necessary):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this IG / specification.
- [ ] My change requires a change to the documentation or narrative (intend) of the IG.
- [ ] I have already updated the documentation / narrative (intend) accordingly.