### PR TITLE
Hinweis zur Handhabung von leeren Elementen und einem :not-Modifier hinzugefügt

### DIFF
--- a/ImplementationGuide/markdown/UebergreifendeFestlegungen/UebergreifendeFestlegungen_Suchparameter.md
+++ b/ImplementationGuide/markdown/UebergreifendeFestlegungen/UebergreifendeFestlegungen_Suchparameter.md
@@ -54,7 +54,7 @@ Diese Suchanfrage gibt alle Patienten zurück zum Client, welche in einem Adress
 
 ### Token
 
-Der Modifier `:not` MUSS für alle spezifizierten Suchparameter vom Typ 'Token' unterstützt werden, sofern diese auf die Datentypen "code", "Coding" oder "CodeableConcept" verwendet werden.
+Der Modifier `:not` MUSS für alle spezifizierten Suchparameter vom Typ 'Token' unterstützt werden, sofern diese auf die Datentypen "code", "Coding" oder "CodeableConcept" verwendet werden. Bei einer Suche mit dem ":not"-Modifier MÜSSEN Ressourcen, die keinen Wert für das Element des Suchparameters enthalten, im Suchergebnis enthalten sein.
 
 Der Modifier `:text` MUSS für alle spezifizierten Suchparameter vom Typ 'Token' unterstützt werden, sofern diese auf die Datentypen "Coding" oder "CodeableConcept" verwendet werden.
 


### PR DESCRIPTION
vgl. https://www.hl7.org/fhir/r4/search.html#token

“Note that this includes resources that have no value for the parameter”. PR fügt keine neuen Anforderungen hinzu.
Ursprung: https://github.com/gematik/spec-ISiK-Terminplanung/issues/210