### PR TITLE
PTDATA-1543: Entfernung des fixed values auf DocumentReference.masterIdentifier.system

### DIFF
--- a/Resources/fsh-generated/resources/Bundle-Suchergebnis-Beispiel.json
+++ b/Resources/fsh-generated/resources/Bundle-Suchergebnis-Beispiel.json
@@ -31,10 +31,6 @@
             "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenMetadaten"
           ]
         },
-        "masterIdentifier": {
-          "system": "urn:ietf:rfc:3986",
-          "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
-        },
         "type": {
           "coding": [
             {
@@ -60,6 +56,10 @@
             ]
           }
         ],
+        "masterIdentifier": {
+          "system": "urn:ietf:rfc:3986",
+          "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
+        },
         "status": "current",
         "description": "Molekularpathologiebefund vom 31.12.21",
         "subject": {

--- a/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-jpeg-example-short.json
+++ b/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-jpeg-example-short.json
@@ -12,10 +12,6 @@
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenMetadaten"
     ]
   },
-  "masterIdentifier": {
-    "system": "urn:ietf:rfc:3986",
-    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
-  },
   "type": {
     "coding": [
       {
@@ -24,6 +20,10 @@
         "display": "Fotodokumentation Operation"
       }
     ]
+  },
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
   },
   "status": "current",
   "description": "Fotodokumentation Operation vom 31.12.21",

--- a/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-jpeg-example.json
+++ b/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-jpeg-example.json
@@ -12,10 +12,6 @@
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenMetadaten"
     ]
   },
-  "masterIdentifier": {
-    "system": "urn:ietf:rfc:3986",
-    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
-  },
   "type": {
     "coding": [
       {
@@ -24,6 +20,10 @@
         "display": "Fotodokumentation Operation"
       }
     ]
+  },
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
   },
   "status": "current",
   "description": "Fotodokumentation Operation vom 31.12.21",

--- a/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-pdf-example-short.json
+++ b/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-pdf-example-short.json
@@ -12,10 +12,6 @@
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenMetadaten"
     ]
   },
-  "masterIdentifier": {
-    "system": "urn:ietf:rfc:3986",
-    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
-  },
   "type": {
     "coding": [
       {
@@ -24,6 +20,10 @@
         "display": "Molekularpathologiebefund"
       }
     ]
+  },
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
   },
   "status": "current",
   "description": "Molekularpathologiebefund vom 31.12.21",

--- a/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-pdf-example.json
+++ b/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-client-with-binary-pdf-example.json
@@ -12,10 +12,6 @@
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenMetadaten"
     ]
   },
-  "masterIdentifier": {
-    "system": "urn:ietf:rfc:3986",
-    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
-  },
   "type": {
     "coding": [
       {
@@ -24,6 +20,10 @@
         "display": "Molekularpathologiebefund"
       }
     ]
+  },
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
   },
   "status": "current",
   "description": "Molekularpathologiebefund vom 31.12.21",

--- a/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-server.json
+++ b/Resources/fsh-generated/resources/DocumentReference-dok-beispiel-server.json
@@ -12,10 +12,6 @@
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenMetadaten"
     ]
   },
-  "masterIdentifier": {
-    "system": "urn:ietf:rfc:3986",
-    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
-  },
   "type": {
     "coding": [
       {
@@ -41,6 +37,10 @@
       ]
     }
   ],
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.2.840.113556.1.8000.2554.58783.21864.3474.19410.44358.58254.41281.46340"
+  },
   "status": "current",
   "description": "Molekularpathologiebefund vom 31.12.21",
   "subject": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -42,9 +42,8 @@
         "id": "DocumentReference.masterIdentifier.system",
         "path": "DocumentReference.masterIdentifier.system",
         "short": "Namensraum des Identifiers",
-        "comment": "Fix: `urn:ietf:rfc:3986`",
+        "comment": "Bei OIDs und UUIDs ist hier stets der Wert `urn:ietf:rfc:3986` anzugeben. Weitere Hinweise zur AbbildungVerwendung von MasterIdentifiern und deren Abbildung auf FHIR sind [in IHE-ITI](https://profiles.ihe.net/ITI/TF/Volume2/ch-Z.html#z.9-fhir-data-types) zu finden.",
         "min": 1,
-        "patternUri": "urn:ietf:rfc:3986",
         "mustSupport": true
       },
       {

--- a/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
@@ -22,9 +22,8 @@ Elemente mit ValueSet-Bindings ohne verbindliche Vorgabe seitens IHE wurden auf 
 * masterIdentifier 1.. MS
   * ^short = "Versionsspezifische OID des Dokumentes"
   * system 1..1 MS
-  * system = "urn:ietf:rfc:3986"
     * ^short = "Namensraum des Identifiers"
-    * ^comment = "Fix: `urn:ietf:rfc:3986`"
+    * ^comment = "Bei OIDs und UUIDs ist hier stets der Wert `urn:ietf:rfc:3986` anzugeben. Weitere Hinweise zur AbbildungVerwendung von MasterIdentifiern und deren Abbildung auf FHIR sind [in IHE-ITI](https://profiles.ihe.net/ITI/TF/Volume2/ch-Z.html#z.9-fhir-data-types) zu finden."
   * value 1..1 MS
     * ^short = "Wert des Identifiers"
     * ^comment = "OID mit URI-Präfix &quot;urn:oid:&quot;. Es sei darauf hingewiesen, dass OIDs auf Basis von UUIDs generiert werden können, ohne einen eigenen Namesraum zu beantragen. Zunächst müssen hierzu alle 128 Bit der UUID in einen Integer-Wert umgerechnet werden. Das Ergebnis muss ohne Bindestriche an die Root-OID '2.25' angehängt werden. Siehe [IHE International - Creating Unique IDs - OID and UUID](https://wiki.ihe.net/index.php/Creating_Unique_IDs_-_OID_and_UUID)."

--- a/guides/ISiK-Dokumentenaustausch-Stufe-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/ISiK-Dokumentenaustausch-Stufe-5/Einfuehrung/ReleaseNotes.page.md
@@ -9,6 +9,11 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 Offene Punkte und bekannte Probleme siehe [GitHub Issues](https://github.com/gematik/ISiK-Dokumentenaustausch/issues?q=is%3Aissue+is%3Aopen+label%3A%22offene+Punkte+Ballot%22)
 
+Version: 5.0.0
+* `fixed`: Entfernung des fixed values "urn:ietf:rfc:3986" auf DocumentReference.masterIdentifier.system, um auch Identifier der Form root+extension zu ermöglichen, siehe
+https://profiles.ihe.net/ITI/TF/Volume2/ch-Z.html#z.9-fhir-data-types
+https://chat.fhir.org/#narrow/channel/287581-german.2Fisik/topic/.5BDOK.5D.20masterIdentifier.20als.20OID.3F
+
 Version: 4.0.2
 
 Datum: 19.3.2025


### PR DESCRIPTION
`fixed`: Entfernung des fixed values "urn:ietf:rfc:3986" auf DocumentReference.masterIdentifier.system, um auch Identifier der Form root+extension zu ermöglichen, siehe
https://profiles.ihe.net/ITI/TF/Volume2/ch-Z.html#z.9-fhir-data-types
https://chat.fhir.org/#narrow/channel/287581-german.2Fisik/topic/.5BDOK.5D.20masterIdentifier.20als.20OID.3F

https://service.gematik.de/browse/PTDATA-1543
