### PR TITLE
Update sushi-config and package.json to include hl7.fhir.uv.sdc version 3.0.0

### DIFF
--- a/Resources/sushi-config.yaml
+++ b/Resources/sushi-config.yaml
@@ -7,8 +7,8 @@ dependencies:
   hl7.fhir.uv.ips: 1.1.0
   hl7.fhir.uv.subscriptions-backport.r4: 1.1.0
   de.basisprofil.r4: 1.5.3
-#  ihe.iti.mhd: 4.2.2
   de.ihe-d.terminology: 3.0.1
   dvmd.kdl.r4: 2025.0.0
   ihe.formatcode.fhir: 1.2.0
+  hl7.fhir.uv.sdc: 3.0.0
   

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "ihe.iti.mhd": "4.2.2",
     "de.ihe-d.terminology": "3.0.1",
     "dvmd.kdl.r4": "2025.0.0",
-    "hl7.fhir.core": "4.0.1",
-    "hl7.fhir.r4b.core": "4.3.0",
-    "hl7.fhir.r4.core": "4.0.1"
+    "hl7.fhir.uv.sdc": "3.0.0"
   }
 }


### PR DESCRIPTION
This pull request updates dependency configurations by removing unused FHIR core packages and adding a new dependency for Structured Data Capture (SDC). These changes streamline the dependency list and align it with current project requirements.

### Dependency Updates:

* [`Resources/sushi-config.yaml`](diffhunk://#diff-a3204f21b2683a9429c1a6dd8d3b7839739849a0331a386ce6f3424cb64553f6L10-R13): Removed the commented-out dependency for `ihe.iti.mhd` and added a new dependency for `hl7.fhir.uv.sdc` version `3.0.0`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R13): Removed unused FHIR core dependencies (`hl7.fhir.core`, `hl7.fhir.r4b.core`, and `hl7.fhir.r4.core`) and added the `hl7.fhir.uv.sdc` dependency version `3.0.0`.