### PR TITLE
Fix naming for ISiKCapabilityStatement topic and canonical URL

### DIFF
--- a/guides/ICU-5/Einfuehrung/Artefakte/CapabilityStatements/Rolle-CapabilityStatementMinimalAdministrativeDataSource.page.md
+++ b/guides/ICU-5/Einfuehrung/Artefakte/CapabilityStatements/Rolle-CapabilityStatementMinimalAdministrativeDataSource.page.md
@@ -1,6 +1,6 @@
 ---
-topic: ISiKCapabilityStatementMinimalAdministrativeDataSourceRolle
-canonical: https://gematik.de/fhir/isik/CapabilityStatement/ISiKCapabilityStatementMinimalAdministrativeDataSourceRolle
+topic: ISiKCapabilityStatementStammdatenRolle
+canonical: https://gematik.de/fhir/isik/CapabilityStatement/ISiKCapabilityStatementStammdatenRolle
 ---
 ##  <fql output="inline" headers="false">
 from


### PR DESCRIPTION
Update the topic and canonical URL to reflect the correct naming convention for the ISiKCapabilityStatement.