### PR TITLE
refactor: Rename SubscriptionNotificationTypes to remove sushi warnings

### DIFF
--- a/Resources/fsh-generated/resources/CodeSystem-subscription-notification-type.json
+++ b/Resources/fsh-generated/resources/CodeSystem-subscription-notification-type.json
@@ -2,7 +2,7 @@
   "resourceType": "CodeSystem",
   "status": "active",
   "content": "complete",
-  "name": "SubscriptionNotificationType",
+  "name": "SubscriptionNotificationTypeCS",
   "id": "subscription-notification-type",
   "title": "SubscriptionNotificationType",
   "description": "The type of notification represented by the status message.",

--- a/Resources/fsh-generated/resources/ValueSet-subscription-notification-type.json
+++ b/Resources/fsh-generated/resources/ValueSet-subscription-notification-type.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "ValueSet",
   "status": "active",
-  "name": "SubscriptionNotificationType",
+  "name": "SubscriptionNotificationTypeVS",
   "id": "subscription-notification-type",
   "title": "SubscriptionNotificationType",
   "description": "The type of notification represented by the status message.",

--- a/Resources/input/fsh/Subscription/BackportSubscriptionStatusR4Fixed.fsh
+++ b/Resources/input/fsh/Subscription/BackportSubscriptionStatusR4Fixed.fsh
@@ -66,7 +66,7 @@ Diese lokale Definition wird durch das offizielle `backport-subscription-status-
 * parameter[type].name ^short = "Slice discriminator: the type of event for this notification"
 * parameter[type].value[x] 1.. MS
 * parameter[type].value[x] only code
-* parameter[type].value[x] from SubscriptionNotificationType (required)
+* parameter[type].value[x] from SubscriptionNotificationTypeVS (required)
 * parameter[type].value[x] ^short = "The type of event being conveyed with this notificaiton."
 * parameter[eventsSinceSubscriptionStart] ^short = "Parameter containing the number of events since this subscription started"
 * parameter[eventsSinceSubscriptionStart].name = "events-since-subscription-start" (exactly)

--- a/Resources/input/fsh/Subscription/SubscriptionNotificationTypeBackport.fsh
+++ b/Resources/input/fsh/Subscription/SubscriptionNotificationTypeBackport.fsh
@@ -1,4 +1,4 @@
-ValueSet: SubscriptionNotificationType
+ValueSet: SubscriptionNotificationTypeVS
 Id: subscription-notification-type
 Title: "SubscriptionNotificationType"
 Description: "The type of notification represented by the status message."
@@ -21,9 +21,9 @@ Description: "The type of notification represented by the status message."
 * ^contact.telecom[+].system = #email
 * ^contact.telecom[=].value = "fhir@lists.hl7.org"
 * ^immutable = true
-* include codes from system SubscriptionNotificationType
+* include codes from system SubscriptionNotificationTypeCS
 
-CodeSystem: SubscriptionNotificationType
+CodeSystem: SubscriptionNotificationTypeCS
 Id: subscription-notification-type
 Title: "SubscriptionNotificationType"
 Description: "The type of notification represented by the status message."


### PR DESCRIPTION
This pull request updates the naming conventions for `CodeSystem` and `ValueSet` resources related to subscription notification types to improve consistency and clarity and remove sushi warnings. 

No Canonical or ID was changed, just the names.

### Updates to Naming Conventions:

* [`Resources/fsh-generated/resources/CodeSystem-subscription-notification-type.json`](diffhunk://#diff-e6afcc42c19918310a424259c6d9bef009e0b0179a2adb5b504fbf5f4fbe55f5L5-R5): Renamed the `name` field from `SubscriptionNotificationType` to `SubscriptionNotificationTypeCS` to reflect the `CodeSystem` resource type.
* [`Resources/fsh-generated/resources/ValueSet-subscription-notification-type.json`](diffhunk://#diff-41f82be7f2a44e5474a6acdfd3e82cc65f0bcbea087bb32669e0dcc7c1e538f2L4-R4): Renamed the `name` field from `SubscriptionNotificationType` to `SubscriptionNotificationTypeVS` to reflect the `ValueSet` resource type.

### Reference Updates:

* [`Resources/input/fsh/Subscription/BackportSubscriptionStatusR4Fixed.fsh`](diffhunk://#diff-070134c8fd9fc56d7d0b40b89db16b0fbe730b4745cad177b74f3335700a1880L69-R69): Updated the reference for `parameter[type].value[x]` to use `SubscriptionNotificationTypeVS` instead of `SubscriptionNotificationType`.
* [`Resources/input/fsh/Subscription/SubscriptionNotificationTypeBackport.fsh`](diffhunk://#diff-7d0fa6f07aa8f87f37a719b5339dba11dfa044d2f0fb5d99502bc617be917951L1-R1): Updated `ValueSet` and `CodeSystem` references to `SubscriptionNotificationTypeVS` and `SubscriptionNotificationTypeCS`, respectively, and adjusted the `include codes from system` directive accordingly. [[1]](diffhunk://#diff-7d0fa6f07aa8f87f37a719b5339dba11dfa044d2f0fb5d99502bc617be917951L1-R1) [[2]](diffhunk://#diff-7d0fa6f07aa8f87f37a719b5339dba11dfa044d2f0fb5d99502bc617be917951L24-R26)