### PR TITLE
Stufe 5/lab/fix/sct optional ptdata 1681

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchung.json
@@ -56,7 +56,7 @@
           ],
           "rules": "open"
         },
-        "min": 2,
+        "min": 1,
         "mustSupport": true
       },
       {
@@ -86,16 +86,6 @@
           "system": "http://loinc.org"
         },
         "mustSupport": true
-      },
-      {
-        "id": "Observation.code.coding:snomed",
-        "path": "Observation.code.coding",
-        "sliceName": "snomed",
-        "min": 1,
-        "max": "1",
-        "patternCoding": {
-          "system": "http://snomed.info/sct"
-        }
       },
       {
         "id": "Observation.code.text",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungCRP.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungCRP.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "55235003",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungCRP.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungCRP.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungGFR.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungGFR.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "80274001",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungGFR.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungGFR.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungHb.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungHb.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "416125006",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungHb.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungHb.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungPCT.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungPCT.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "418752001",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungPCT.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungPCT.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungSerumkreatinin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungSerumkreatinin.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "70901006",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungSerumkreatinin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungSerumkreatinin.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTSH.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTSH.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "61167004",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTSH.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTSH.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungThrombozyten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungThrombozyten.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungThrombozyten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungThrombozyten.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "365632008",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTroponin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTroponin.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "min": 0,
+        "max": "1",
         "patternCoding": {
           "code": "105000003",
           "system": "http://snomed.info/sct"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTroponin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchungTroponin.json
@@ -30,6 +30,8 @@
         "id": "Observation.code.coding:snomed",
         "path": "Observation.code.coding",
         "sliceName": "snomed",
+        "short": "Primärer SNOMED CT-Code ohne Methodenbezug",
+        "comment": "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich.",
         "min": 0,
         "max": "1",
         "patternCoding": {

--- a/Resources/input/fsh/Labor/ISiK-CapabilityStatementLaborMinimalRolle.fsh
+++ b/Resources/input/fsh/Labor/ISiK-CapabilityStatementLaborMinimalRolle.fsh
@@ -25,21 +25,21 @@ Usage: #definition
   * resource[+]
     * type = #Observation
     * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $iSiKLaboruntersuchungSerumkreatinin
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungSerumkreatinin)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $iSiKLaboruntersuchungPCT
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungPCT)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $iSiKLaboruntersuchungCRP
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungCRP)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $iSiKLaboruntersuchungHb
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungHb)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $iSiKLaboruntersuchungTroponin
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungTroponin)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $ISiKLaboruntersuchungGFR
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungGFR)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $ISiKLaboruntersuchungThrombozyten
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungThrombozyten)
       * insert CapabilityStatementExpectationExt(SHALL)
-    * supportedProfile[+] = $ISiKLaboruntersuchungTSH
+    * supportedProfile[+] = Canonical(ISiKLaboruntersuchungTSH)
       * insert CapabilityStatementExpectationExt(SHALL)
     * interaction[+]
       * insert CapabilityStatementExpectationExt(SHALL)

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchung.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchung.fsh
@@ -25,9 +25,8 @@ In FHIR werden Untersuchungen, bzw. Beobachtungen als [`Observation`](https://hl
     * code 1.. MS
     * display MS
   * text MS
-  * coding contains loinc 1.. MS and snomed 1..1
+  * coding contains loinc 1.. MS
   * coding[loinc] ^patternCoding.system = $loinc
-  * coding[snomed] ^patternCoding.system = $sct
 * subject only Reference(Patient)  
 * subject 1.. MS
   * ^short = "Referenz auf den Patienten"

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungCRP.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungCRP.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungCRP
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung CRP eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesCRP 
 * code.coding[snomed] = $sct#55235003
 * valueQuantity from ObservationUnitsCRP 

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungCRP.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungCRP.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungCRP
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung CRP eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesCRP 
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#55235003
 * valueQuantity from ObservationUnitsCRP 
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungGFR.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungGFR.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungGFR
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung GFR eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesGFR
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#80274001
 * valueQuantity from ObservationUnitsGFR
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungGFR.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungGFR.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungGFR
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung GFR eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesGFR
 * code.coding[snomed] = $sct#80274001
 * valueQuantity from ObservationUnitsGFR

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungHb.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungHb.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungHb
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Hb eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesHb
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#416125006
 * valueQuantity from ObservationUnitsHb
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungHb.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungHb.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungHb
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Hb eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesHb
 * code.coding[snomed] = $sct#416125006
 * valueQuantity from ObservationUnitsHb

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungPCT.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungPCT.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungPCT
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung PCT eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesPCT (required)
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#418752001
 * valueQuantity from ObservationUnitsPCT (required)
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungPCT.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungPCT.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungPCT
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung PCT eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesPCT (required)
 * code.coding[snomed] = $sct#418752001
 * valueQuantity from ObservationUnitsPCT (required)

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungSerumkreatinin.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungSerumkreatinin.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungSerumkreatinin
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Serumkreatinin eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesSerumkreatinin
 * code.coding[snomed] = $sct#70901006
 * valueQuantity from ObservationUnitsSerumkreatinin

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungSerumkreatinin.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungSerumkreatinin.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungSerumkreatinin
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Serumkreatinin eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesSerumkreatinin
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#70901006
 * valueQuantity from ObservationUnitsSerumkreatinin
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungTSH.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungTSH.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungTSH
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung TSH eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesTSH
 * code.coding[snomed] = $sct#61167004
 * valueQuantity from ObservationUnitsTSH

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungTSH.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungTSH.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungTSH
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung TSH eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesTSH
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#61167004
 * valueQuantity from ObservationUnitsTSH
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungThrombozyten.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungThrombozyten.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungThrombozyten
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Thrombozyten eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesThrombozyten
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#365632008
 * valueQuantity from ObservationUnitsThrombozyten
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungThrombozyten.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungThrombozyten.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungThrombozyten
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Thrombozyten eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesThrombozyten
 * code.coding[snomed] = $sct#365632008
 * valueQuantity from ObservationUnitsThrombozyten

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungTroponin.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungTroponin.fsh
@@ -3,8 +3,8 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungTroponin
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Troponin eines Patienten in ISiK Szenarien."
 * insert Meta
-* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesTroponin
+* insert LaboratorySnomedSliceRuleSet
 * code.coding[snomed] = $sct#105000003
 * valueQuantity from ObservationUnitsTroponin
 * referenceRange MS

--- a/Resources/input/fsh/Labor/ISiKLaboruntersuchungTroponin.fsh
+++ b/Resources/input/fsh/Labor/ISiKLaboruntersuchungTroponin.fsh
@@ -3,6 +3,7 @@ Parent: ISiKLaboruntersuchung
 Id: ISiKLaboruntersuchungTroponin
 Description: "Dieses Profil ermöglicht die Abbildung der Laboruntersuchung Troponin eines Patienten in ISiK Szenarien."
 * insert Meta
+* code.coding contains snomed 0..1
 * code.coding[loinc] from ObservationCodesTroponin
 * code.coding[snomed] = $sct#105000003
 * valueQuantity from ObservationUnitsTroponin

--- a/Resources/input/fsh/_Commons/LaboratorySnomedSliceRuleSet.fsh
+++ b/Resources/input/fsh/_Commons/LaboratorySnomedSliceRuleSet.fsh
@@ -1,0 +1,5 @@
+RuleSet: LaboratorySnomedSliceRuleSet
+* code.coding contains snomed 0..1
+* code.coding[snomed]
+  * ^short = "Primärer SNOMED CT-Code ohne Methodenbezug"
+  * ^comment = "Motivation 0..1 Kardinalität: Abstrakter SNOMED CT-Code ohne Methodenbezug. Weitere (SCT) Codings mit Methodenbezug sind durch das offene Slicing möglich."

--- a/Resources/input/fsh/_Commons/aliases.fsh
+++ b/Resources/input/fsh/_Commons/aliases.fsh
@@ -123,13 +123,3 @@ Alias: $appointmentStatus = http://hl7.org/fhir/appointmentstatus
 Alias: $cancelationReason = http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason
 
 Alias: $IEEE11073 = urn:iso:std:iso:11073:10101
-
-Alias: $iSiKLaboruntersuchungSerumkreatinin = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungSerumkreatinin
-Alias: $iSiKLaboruntersuchungPCT = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungPCT
-Alias: $iSiKLaboruntersuchungCRP = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungCRP
-Alias: $iSiKLaboruntersuchungHb = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungHb
-Alias: $iSiKLaboruntersuchungTroponin =  https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungTroponin
-
-Alias: $ISiKLaboruntersuchungGFR = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungGFR
-Alias: $ISiKLaboruntersuchungThrombozyten = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungThrombozyten
-Alias: $ISiKLaboruntersuchungTSH = https://gematik.de/fhir/isik/StructureDefinition/ISiKLaboruntersuchungTSH

--- a/guides/Labor-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Labor-5/Einfuehrung/ReleaseNotes.page.md
@@ -13,6 +13,8 @@ Mit der Stufe 5 werden alle Technical Corrections der Stufe 4 bindend.
 Datum: tbd
 
 - `improve`: Erlaubte referenzierbare Profile von Element Subject auf Patient reduziert https://github.com/gematik/spec-ISiK-Basismodul/pull/727
+- `change`: Die Mindestkardinalität für den SCT-Slice in ISiKLaboruntersuchung wurde von 1 auf 0
+  reduziert.
 
 ---
 

--- a/guides/Labor-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Labor-5/Einfuehrung/ReleaseNotes.page.md
@@ -14,7 +14,7 @@ Datum: tbd
 
 - `improve`: Erlaubte referenzierbare Profile von Element Subject auf Patient reduziert https://github.com/gematik/spec-ISiK-Basismodul/pull/727
 - `change`: Die Mindestkardinalität für den SCT-Slice in ISiKLaboruntersuchung wurde von 1 auf 0
-  reduziert.
+  reduziert. https://github.com/gematik/spec-ISiK-Basismodul/pull/730
 
 ---
 

--- a/guides/Labor-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Labor-5/Einfuehrung/ReleaseNotes.page.md
@@ -14,7 +14,8 @@ Datum: tbd
 
 - `improve`: Erlaubte referenzierbare Profile von Element Subject auf Patient reduziert https://github.com/gematik/spec-ISiK-Basismodul/pull/727
 - `change`: Die Mindestkardinalität für den SCT-Slice in ISiKLaboruntersuchung wurde von 1 auf 0
-  reduziert. https://github.com/gematik/spec-ISiK-Basismodul/pull/730
+  reduziert. Das Pattern auf code.coding[snomed].system wurde entfernt um Mehrfachkodierungen in
+  SnomedCT nicht zu verhindern. https://github.com/gematik/spec-ISiK-Basismodul/pull/730
 - `improve`: Einschränkung des MS-Flag auf specimen und method für alle Profile aus dem Labormodul https://github.com/gematik/spec-ISiK-Basismodul/pull/735 
 
 


### PR DESCRIPTION
This pull request introduces several changes to the `ISiKLaboruntersuchung` FHIR profiles and related files. The primary focus is on modifying the cardinality and structure of SNOMED coding, removing outdated aliases, and updating references to use canonical URLs. These changes aim to improve consistency and align with updated specifications.

### Updates to SNOMED Coding Cardinality:
* Changed the cardinality of `Observation.code.coding:snomed` from `1..1` to `0..1` across multiple profiles, including `ISiKLaboruntersuchungCRP`, `ISiKLaboruntersuchungGFR`, `ISiKLaboruntersuchungHb`, `ISiKLaboruntersuchungPCT`, `ISiKLaboruntersuchungSerumkreatinin`, `ISiKLaboruntersuchungTSH`, `ISiKLaboruntersuchungThrombozyten`, and `ISiKLaboruntersuchungTroponin`. This makes SNOMED coding optional while maintaining a maximum of one entry. [[1]](diffhunk://#diff-c4c4f4141e3762f5dbc4751cfbe8334b7eb3f6f74b8e0bfbdbb55e77adaa361cR33-R34) [[2]](diffhunk://#diff-24e404028878a156d2b6fea055a1368db9cec107043419af3383183952a0353eR33-R34) [[3]](diffhunk://#diff-7f814e2d46c8e19d07599d93e74b695c0619e220e519d0034e1a8dbdba41cee0R33-R34) [[4]](diffhunk://#diff-42b44aff713969d05b0dac424b5895a7baa4ebe9d7f5e5d1385915f0270e8ef7R33-R34) [[5]](diffhunk://#diff-a82fed743605e6feb39dd178f197422861ac597ee722250912c14cb7670ec8beR33-R34) [[6]](diffhunk://#diff-abaff0e411d7627a8e497c7db83d9ec35ca046590054aea71bb9b47c9ab9fd91R33-R34) [[7]](diffhunk://#diff-80cac7b62a9ef7fde0c5d6a5ac2af587181de36276554e0b5a0e7a02acf1f767R33-R34) [[8]](diffhunk://#diff-442ce431d34f1dfe8c205268d9fedfae93a3ae0674816aabb2c8313b7fd0567fR33-R34)

### Removal of SNOMED Coding Requirements:
* Removed the mandatory inclusion of SNOMED coding in `ISiKLaboruntersuchung` by eliminating the `coding[snomed]` field and its associated system reference.

### Canonical URL Updates:
* Updated `supportedProfile` references in `ISiK-CapabilityStatementLaborMinimalRolle.fsh` to use canonical URLs instead of aliases for better clarity and alignment with FHIR standards.

### Removal of Deprecated Aliases:
* Removed aliases for `ISiKLaboruntersuchung` profiles (e.g., `$iSiKLaboruntersuchungCRP`, `$ISiKLaboruntersuchungGFR`) from `_Commons/aliases.fsh` as they are no longer needed due to the switch to canonical URLs.

### Adjustments to `StructureDefinition` Files:
* Adjusted the `min` cardinality of certain elements in `StructureDefinition-ISiKLaboruntersuchung.json` from `2` to `1` and removed the `Observation.code.coding:snomed` slice, reflecting the optional nature of SNOMED coding. [[1]](diffhunk://#diff-f1d638bcbff7e1762db67841f5841ba9d4e45200176c995e236cd7c2ca7fa34aL59-R59) [[2]](diffhunk://#diff-f1d638bcbff7e1762db67841f5841ba9d4e45200176c995e236cd7c2ca7fa34aL90-L99)