### PR TITLE
Refactor FHIR profiles and soften MS requirements

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKBlutdruckSystemischArteriell.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKBlutdruckSystemischArteriell.json
@@ -391,7 +391,7 @@
         "path": "Observation.component",
         "sliceName": "meanBP",
         "short": "Mittlerer arterieller Druck",
-        "comment": "Motivation MS: Kodierung des mittleren arteriellen Drucks.",
+        "comment": "**Einschränkung der übergreifenden MS-Definition:**  \n  Verfügt ein bestätigungsrelevantes System nicht über die Datenstruktur zur Hinterlegung des mittleren Blutdrucks, \n  so MUSS dieses System die Information NICHT abbilden.\n\n  Motivation zum eingeschränkten MS: Kodierung des mittleren arteriellen Drucks. Von einem medizinischen Experten im Workshop zur ISiK Kommentierung Stufe 5 wurde erläutert, dass .meanBP relevant in der Normalversorgung und üblich in bekannten Systemen sei (allein Diastole und Systole entspricht nicht mehr medizinischem Stand der Praxis). Allerdings rechtfertigt der Stand der Umsetzung in gängigen Systemen eine Implementierungspflicht (MS) für die Schnittstelle nicht.\n  In der ISiK wird die Angabe des mittleren arteriellen Drucks als eingeschränktes Must Support definiert, um eine einheitliche Implementierung zu fördern.\n  ",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKBlutdruckSystemischArteriell.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKBlutdruckSystemischArteriell.json
@@ -117,13 +117,6 @@
         "mustSupport": true
       },
       {
-        "id": "Observation.value[x]",
-        "path": "Observation.value[x]",
-        "short": "Untersuchungsergebnis",
-        "comment": "Motivation MS: Der Wert des Vitalparameters ist das zentrale Ergebnis der Untersuchung",
-        "mustSupport": true
-      },
-      {
         "id": "Observation.dataAbsentReason",
         "path": "Observation.dataAbsentReason",
         "short": "Grund für fehlende Untersuchungsergebnisse",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKEKG.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKEKG.json
@@ -98,13 +98,6 @@
         "mustSupport": true
       },
       {
-        "id": "Observation.value[x]",
-        "path": "Observation.value[x]",
-        "short": "Untersuchungsergebnis",
-        "comment": "Motivation MS: Der Wert des Vitalparameters ist das zentrale Ergebnis der Untersuchung",
-        "mustSupport": true
-      },
-      {
         "id": "Observation.dataAbsentReason",
         "path": "Observation.dataAbsentReason",
         "short": "Grund für fehlende Untersuchungsergebnisse",

--- a/Resources/input/fsh/Vitalparameter/ISiK-Atemfrequenz.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Atemfrequenz.fsh
@@ -10,6 +10,7 @@ In FHIR wird die Atemfrequenz mit der Observation-Ressource repräsentiert.
 ### Kompatibilität
 Das Profil ISiKAtemfrequenz ist vom Profil [VitalSignDE_Atemfrequenz](http://fhir.de/StructureDefinition/observation-de-vitalsign-atemfrequenz) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Respiratory Rate Profile](http://hl7.org/fhir/StructureDefinition/resprate) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/Vitalparameter/ISiK-Blutdruck.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Blutdruck.fsh
@@ -57,7 +57,7 @@ Das Profil ISiKBlutdruckSystemischArteriell ist vom Profil [VitalSignDE_Blutdruc
     * ^short = "Grund für fehlendes Untersuchungsergebniss"
 * component[meanBP] MS
   * ^comment = "**Einschränkung der übergreifenden MS-Definition:**  
-  Verfügt ein bestätigungsrelevantes System nicht über die Datenstruktur zur Hinterlegung des Aktivitätsstatus einer Patienten-Ressource, 
+  Verfügt ein bestätigungsrelevantes System nicht über die Datenstruktur zur Hinterlegung des mittleren Blutdrucks, 
   so MUSS dieses System die Information NICHT abbilden.
 
   Motivation zum eingeschränkten MS: Kodierung des mittleren arteriellen Drucks. Von einem medizinischen Experten im Workshop zur ISiK Kommentierung Stufe 5 wurde erläutert, dass .meanBP relevant in der Normalversorgung und üblich in bekannten Systemen sei (allein Diastole und Systole entspricht nicht mehr medizinischem Stand der Praxis). Allerdings rechtfertigt der Stand der Umsetzung in gängigen Systemen eine Implementierungspflicht (MS) für die Schnittstelle nicht.

--- a/Resources/input/fsh/Vitalparameter/ISiK-Blutdruck.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Blutdruck.fsh
@@ -56,7 +56,13 @@ Das Profil ISiKBlutdruckSystemischArteriell ist vom Profil [VitalSignDE_Blutdruc
     * ^comment = "Motivation MS: Dieses Feld erlaubt die Angabe von Gründen für fehlende Untersuchungsergebnisse"
     * ^short = "Grund für fehlendes Untersuchungsergebniss"
 * component[meanBP] MS
-  * ^comment = "Motivation MS: Kodierung des mittleren arteriellen Drucks."
+  * ^comment = "**Einschränkung der übergreifenden MS-Definition:**  
+  Verfügt ein bestätigungsrelevantes System nicht über die Datenstruktur zur Hinterlegung des Aktivitätsstatus einer Patienten-Ressource, 
+  so MUSS dieses System die Information NICHT abbilden.
+
+  Motivation zum eingeschränkten MS: Kodierung des mittleren arteriellen Drucks. Von einem medizinischen Experten im Workshop zur ISiK Kommentierung Stufe 5 wurde erläutert, dass .meanBP relevant in der Normalversorgung und üblich in bekannten Systemen sei (allein Diastole und Systole entspricht nicht mehr medizinischem Stand der Praxis). Allerdings rechtfertigt der Stand der Umsetzung in gängigen Systemen eine Implementierungspflicht (MS) für die Schnittstelle nicht.
+  In der ISiK wird die Angabe des mittleren arteriellen Drucks als eingeschränktes Must Support definiert, um eine einheitliche Implementierung zu fördern.
+  "
   * ^short = "Mittlerer arterieller Druck"
   * insert Quantity-MS
   * insert Component-Slice-MS

--- a/Resources/input/fsh/Vitalparameter/ISiK-Blutdruck.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Blutdruck.fsh
@@ -12,6 +12,7 @@ Hinweis: In Fällen, in denen fachlich motiviert ausschließlich ein systolische
 ### Kompatibilität
 Das Profil ISiKBlutdruckSystemischArteriell ist vom Profil [VitalSignDE_Blutdruck](http://fhir.de/StructureDefinition/observation-de-vitalsign-blutdruck) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Blood Pressure Profile](http://hl7.org/fhir/StructureDefinition/bp) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+// should not contain ISiKVitalsignCommonsValue since it is not used in this profile
 * insert Observation-category-VSCat-MS
 * code
   * coding contains IEEE11073 0..1

--- a/Resources/input/fsh/Vitalparameter/ISiK-Ekg.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Ekg.fsh
@@ -10,6 +10,7 @@ In FHIR wird das EKG durch die Observation-Ressource repräsentiert, wobei spezi
 ### Kompatibilität
 Das Profil ISiKEKG ist vom Profil [EkgDE](http://fhir.de/StructureDefinition/observation-de-ekg) aus den deutschen Basisprofilen abgeleitet."
 * insert ISiKVitalsignCommons
+// should not contain ISiKVitalsignCommonsValue since it is not used in this profile
 * component MS
   * insert Component-MS
 * component[ekgLeads] MS

--- a/Resources/input/fsh/Vitalparameter/ISiK-GCS.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-GCS.fsh
@@ -12,6 +12,7 @@ Das Profil ISiKGCS ist vom Profil [ScoreDE_GCS](http://fhir.de/StructureDefiniti
 * insert Meta
 * insert Quantity-MS
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * category[survey] MS
   * ^comment = "Motivation MS: Dieses Feld erlaubt die Sortierung und Abfrage anhand der Kategorie der Untersuchung"
   * ^short = "Untersuchungskategorie"

--- a/Resources/input/fsh/Vitalparameter/ISiK-Herzfrequenz.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Herzfrequenz.fsh
@@ -10,6 +10,7 @@ In FHIR wird die Herzfrequenz mit der Observation-Ressource repräsentiert.
 ### Kompatibilität
 Das Profil ISiKHerzfrequenz ist vom Profil [VitalSignDE_Herzfrequenz](http://fhir.de/StructureDefinition/observation-de-vitalsign-herzfrequenz) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Respiratory Rate Profile](http://hl7.org/fhir/StructureDefinition/heartrate) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/Vitalparameter/ISiK-Koerpergewicht.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Koerpergewicht.fsh
@@ -10,6 +10,7 @@ In FHIR wird das Körpergewicht mit der Observation-Ressource repräsentiert.
 ### Kompatibilität
 Das Profil ISiKKoerpergewicht ist vom Profil [VitalSignDE_Koerpergewicht](http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergewicht) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Body Weight Profile](http://hl7.org/fhir/StructureDefinition/bodyweight) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/Vitalparameter/ISiK-Koerpergroesse.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Koerpergroesse.fsh
@@ -10,6 +10,7 @@ In FHIR wird die Körpergröße mit der Observation-Ressource repräsentiert.
 ### Kompatibilität
 Das Profil ISiKKoerpergroesse ist vom Profil [VitalSignDE_Koerpergroesse](http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpergroesse) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Body Height Profile](http://hl7.org/fhir/StructureDefinition/bodyheight) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/Vitalparameter/ISiK-Koerpertemperatur.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Koerpertemperatur.fsh
@@ -10,6 +10,7 @@ In FHIR wird die Körpertemperatur mit der Observation-Ressource repräsentiert.
 ### Kompatibilität
 Das Profil ISiKKoerpertemperatur ist vom Profil [VitalSignDE_Koerpertemperatur](http://fhir.de/StructureDefinition/observation-de-vitalsign-koerpertemperatur) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [OObservation Body Temperature Profile](http://hl7.org/fhir/StructureDefinition/bodytemp) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/Vitalparameter/ISiK-Kopfumfang.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Kopfumfang.fsh
@@ -11,6 +11,7 @@ In FHIR wird der Kopfumfang mit der Observation-Ressource repräsentiert.
 Das Profil ISiKKopfumfang ist vom Profil [VitalSignDE_Kopfumfang](http://fhir.de/StructureDefinition/observation-de-vitalsign-kopfumfang) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Head Circumference Profile](
 http://hl7.org/fhir/StructureDefinition/headcircum) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/Vitalparameter/ISiK-Sauerstoffsaettigung.fsh
+++ b/Resources/input/fsh/Vitalparameter/ISiK-Sauerstoffsaettigung.fsh
@@ -10,6 +10,7 @@ In FHIR wird die arterielle Sauerstoffsättigung mit der Observation-Ressource r
 ### Kompatibilität
 Das Profil ISiKSauerstoffsaettigungArteriell ist vom Profil [VitalSignDE_Arterielle_Sauerstoffsaettigung_Pulsoximetrie](http://fhir.de/StructureDefinition/observation-de-vitalsign-sauerstoffsaettigung-pulsoximetrie) aus den deutschen Basisprofilen abgeleitet. Es ist kompatibel mit dem Profil [Observation Oxygen Saturation Profile](http://hl7.org/fhir/StructureDefinition/oxygensat) aus der FHIR R4 Spezifikation."
 * insert ISiKVitalsignCommons
+* insert ISiKVitalsignCommonsValue
 * insert Quantity-MS
 * insert Observation-category-VSCat-MS
 * code

--- a/Resources/input/fsh/_Commons/ruleset.fsh
+++ b/Resources/input/fsh/_Commons/ruleset.fsh
@@ -100,6 +100,13 @@ RuleSet: supportedLaborProfile
   * extension.url = $capabilitystatement-expectation
   * extension.valueCode = #SHALL
 
+RuleSet: ISiKVitalsignCommonsValue
+// ISiK Vitalsign Commons Value is needed for the ISiK Vitalsign Profiles since some of them are not using the value[x] element (e.g. ISiKBlutdruck is using component).
+* insert Meta
+* value[x] MS
+  * ^comment = "Motivation MS: Der Wert des Vitalparameters ist das zentrale Ergebnis der Untersuchung"
+  * ^short = "Untersuchungsergebnis"
+
 RuleSet: ISiKVitalsignCommons
 * insert Meta
 * status MS
@@ -148,9 +155,7 @@ Bei der Auswahl des Encounters ist zu beachten, dass unter einer (Abrechnungs-)"
 * dataAbsentReason MS
   * ^comment = "Motivation MS: Dieses Feld erlaubt die Angabe von Gründen für fehlende Untersuchungsergebnisse"
   * ^short = "Grund für fehlende Untersuchungsergebnisse"
-* value[x] MS
-  * ^comment = "Motivation MS: Der Wert des Vitalparameters ist das zentrale Ergebnis der Untersuchung"
-  * ^short = "Untersuchungsergebnis"
+
 
 RuleSet: Quantity-MS
 * valueQuantity MS

--- a/guides/Vitalparameter-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Vitalparameter-5/Einfuehrung/ReleaseNotes.page.md
@@ -4,6 +4,12 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von Releases. Die dritte Ziffer Y (Release x.0.y) bezeichnet eine technische Korrektur und versioniert kleinere Änderungen (Packages) während eines Jahres, z. B. 1.0.1.
 
+## Version 5.0.0-rc (Benehmensherstellung)
+
+Datum: tbd.
+
+* Entfernen unnötiger value[x]-Elemente und Schwächung der Must-Support-Anforderungen für Blutdruck .meanBP https://github.com/gematik/spec-ISiK-Basismodul/pull/731
+
 ## Version 5.0.0-rc
 
 Mit der Stufe 5 werden alle Technical Corrections der Stufe 4 bindend.


### PR DESCRIPTION
Remove unnecessary value elements from Blutdruck and adjust the must support requirements for value [x].