### PR TITLE
feat: Mark MedicationAdministration.request as a constrained Must-Support

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKLaboruntersuchung.json
@@ -229,7 +229,7 @@
       {
         "id": "Observation.method",
         "path": "Observation.method",
-        "comment": "**Einschränkung der übergreifenden MS-Definition:** \n  Verfügt ein bestätigungsrelevantes System nicht über die Datenstruktur zur Hinterlegung der Laboruntersuchung zugrundeliegenden Probe, so MUSS dieses System\n   die Information NICHT abbilden. \n   \n   Motivation zum eingeschränkten MS: Die Probe einer Laboruntersuchung ist eine relevante medizinische Information. \n   Da diese Information aktuell häufig nicht übergeben wird, wird das MS eingeschränkt. Es ist dennoch wünschenswert, dass die Probe in der Zukunft übergeben wird",
+        "comment": "**Einschränkung der übergreifenden MS-Definition:** \n  Verfügt ein bestätigungsrelevantes System nicht über die Datenstruktur zur Hinterlegung der zugrundeliegenden Methode, so MUSS dieses System\n   die Information NICHT abbilden. \n   \n   Motivation zum eingeschränkten MS: Die Untersuchungsmethode einer Laboruntersuchung ist eine relevante medizinische Information. \n   Da diese Information aktuell häufig nicht übergeben wird, wird das MS eingeschränkt. Es ist dennoch wünschenswert, dass die Probe in der Zukunft übergeben wird.",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerabreichung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerabreichung.json
@@ -275,6 +275,13 @@
         "mustSupport": true
       },
       {
+        "id": "MedicationAdministration.request",
+        "path": "MedicationAdministration.request",
+        "short": "Referenz auf die Verordnung",
+        "comment": "**Einschränkung der übergreifenden MS-Definition:**\n  Verfügt ein bestätigungsrelevantes System nicht über die Möglichkeit zur Abbildung der zugrunde liegenden Verordnung einer Verabreichung, \n  so MUSS dieses System die Information NICHT abbilden.\n\n  Motivation zum eingeschränkten MS: Die referenzierte Verordnung (`MedicationRequest`) bildet in der Regel die Grundlage einer Verabreichung (`MedicationAdministration`). \n  Aus fachlicher Sicht ist die Verknüpfung beider Ressourcen wesentlich, da sie die Nachvollziehbarkeit der therapeutischen Maßnahme unterstützt. \n  Allerdings existieren in der Versorgungspraxis auch Systeme, die keine strukturierte Erfassung oder Referenzierung einer zugrundeliegenden Verordnung vorsehen. \n  Daher wird `MedicationAdministration.request` in ISiK als eingeschränktes Must Support definiert, um eine einheitliche  Implementierung zu fördern.",
+        "mustSupport": true
+      },
+      {
         "id": "MedicationAdministration.note",
         "path": "MedicationAdministration.note",
         "mustSupport": true

--- a/Resources/input/fsh/Medikation/ISiKMedikationsVerabreichung.fsh
+++ b/Resources/input/fsh/Medikation/ISiKMedikationsVerabreichung.fsh
@@ -74,6 +74,17 @@ Handelt es sich bei Erfassung um eine medizinische Verabreichungsdokumentation, 
   * ^short = "Grund der Medikation (Referenz)"
   * ^comment = "  Festlegung zum MS: Die Elemente .reasonCode und .reasonReference MÜSSEN nach OR-Logik in der Ausgabe verwendet werden, d.h. nur eines MUSS geliefert werden können. Weiterhin MÜSSEN beide Elemente interpretiert werden können."
   * reference 1..1 MS
+* request MS
+  * ^short = "Referenz auf die Verordnung"
+  * ^comment = """**Einschränkung der übergreifenden MS-Definition:**
+  Verfügt ein bestätigungsrelevantes System nicht über die Möglichkeit zur Abbildung der zugrunde liegenden Verordnung einer Verabreichung, 
+  so MUSS dieses System die Information NICHT abbilden.
+
+  Motivation zum eingeschränkten MS: Die referenzierte Verordnung (`MedicationRequest`) bildet in der Regel die Grundlage einer Verabreichung (`MedicationAdministration`). 
+  Aus fachlicher Sicht ist die Verknüpfung beider Ressourcen wesentlich, da sie die Nachvollziehbarkeit der therapeutischen Maßnahme unterstützt. 
+  Allerdings existieren in der Versorgungspraxis auch Systeme, die keine strukturierte Erfassung oder Referenzierung einer zugrundeliegenden Verordnung vorsehen. 
+  Daher wird `MedicationAdministration.request` in ISiK als eingeschränktes Must Support definiert, um eine einheitliche  Implementierung zu fördern.
+  """
 * note MS
   * text MS
     * ^short = "Freitext-Notiz"

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -6,6 +6,14 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 ## Version 5.0.0-rc1
 
+Datum: tbd
+
+* `improve` Das Element MedicationAdministration.request im Profil ISiKMedikationsVerabreichung
+  wurde als eingeschränktes Must-Support gekennzeichnet, da die Angabe der zugrunde liegenden
+  Verordnung fachlich relevant ist, aber nicht in allen Systemen strukturell abbildbar.
+
+## Version 5.0.0-rc (Kommentierung)
+
 Mit der Stufe 5 werden alle Technical Corrections der Stufe 4 bindend.
 
 Datum: 09.04.2025

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -22,7 +22,7 @@ Datum: tbd.
 
 ---
 
-## Version 5.0.0-rc1
+## Version 5.0.0-rc (Kommentierung)
 
 Mit der Stufe 5 werden alle Technical Corrections der Stufe 4 bindend.
 

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -19,8 +19,8 @@ Datum: tbd.
   ePA/eMP und präzisere Darstellung der enthaltenen Informationen
   (MedicationStatements). https://github.com/gematik/spec-ISiK-Basismodul/pull/733
 * `improve` ISiKMedikationsVerordnung: Kommentar zu priorPrescription hinzugefügt und Definitionen
-    in den Kommentaren beider Elemente (priorPrescription und extension.medicationRequestReplaces)
-    sprachlich und fachlich überarbeitet. https://github.com/gematik/spec-ISiK-Basismodul/pull/736
+  in den Kommentaren beider Elemente (priorPrescription und extension.medicationRequestReplaces)
+  sprachlich und fachlich überarbeitet. https://github.com/gematik/spec-ISiK-Basismodul/pull/736
 
 ---
 

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -10,7 +10,8 @@ Datum: tbd
 
 * `improve` Das Element MedicationAdministration.request im Profil ISiKMedikationsVerabreichung
   wurde als eingeschränktes Must-Support gekennzeichnet, da die Angabe der zugrunde liegenden
-  Verordnung fachlich relevant ist, aber nicht in allen Systemen strukturell abbildbar.
+  Verordnung fachlich relevant ist, aber nicht in allen Systemen strukturell
+  abbildbar. https://github.com/gematik/spec-ISiK-Basismodul/pull/734
 
 ## Version 5.0.0-rc (Kommentierung)
 


### PR DESCRIPTION
This pull request introduces an enhancement to the `ISiKMedikationsVerabreichung` profile by marking the `MedicationAdministration.request` element as an "eingeschränktes Must Support" (restricted Must Support). This change aims to balance the need for linking medication administrations to their underlying orders with the practical limitations of certain systems. The update is reflected in multiple files, including the JSON structure definition, FSH input file, and release notes.

### Changes to `ISiKMedikationsVerabreichung` profile:

* **Addition of `MedicationAdministration.request` element**:
  - Marked as "eingeschränktes Must Support" to indicate that systems unable to represent the underlying order are not required to include this information. This ensures compatibility while promoting traceability of therapeutic actions. [[1]](diffhunk://#diff-5c3ca8376be4a8b287c03b12b327b43e562df805b968e291005da4362b3097c9R277-R283) [[2]](diffhunk://#diff-b8ee14fa818d84bf965cf44ec4719d1c560193879c96365e75f13dc407507a0fR77-R87)

### Documentation updates:

* **Release notes for version 5.0.0-rc1**:
  - Added a note explaining the rationale for marking `MedicationAdministration.request` as restricted Must Support. This provides context for implementers regarding its importance and limitations.