### PR TITLE
feat: Enhance comments for medication request extension and priorPrescription to clarify usage and distinctions

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json
@@ -106,7 +106,7 @@
         "path": "MedicationRequest.extension",
         "sliceName": "medicationRequestReplaces",
         "short": "Welche Medikationsverordnung wird ersetzt?",
-        "comment": "Begründung des Must-Support: historische Nachvollziehbarkeit\n\n  Hinweis: Welche Medikationsverordnung wird ersetzt?",
+        "comment": "Begründung des Must-Support: historische Nachvollziehbarkeit ersetzter Verordnungen.\n\n    Hinweis: Diese Extension dient der Abbildung einer Verordnung, die eine vorherige Medikation ersetzt - z.B. bei Unverträglichkeit, mangelnder Wirksamkeit oder Wechsel des Wirkstoffs.\n    Abgrenzung: Im Gegensatz zum Feld 'priorPrescription', das eine Folgeverordnung bei fortgesetzter Therapie beschreibt, kennzeichnet diese Extension eine bewusste Ablösung der ursprünglichen Verordnung.",
         "min": 0,
         "max": "1",
         "type": [
@@ -374,7 +374,7 @@
         "id": "MedicationRequest.reasonReference",
         "path": "MedicationRequest.reasonReference",
         "short": "Grund der Medikation (Referenz)",
-        "comment": "  Festlegung zum MS: Die Elemente .reasonCode und .reasonReference MÜSSEN nach OR-Logik in der Ausgabe verwendet werden, d.h. nur eines MUSS geliefert werden können. Weiterhin MÜSSEN beide Elemente interpretiert werden können.\n  Begründung zu Must-Support: Konsolidierung mit MII.",
+        "comment": "Festlegung zum MS: Die Elemente .reasonCode und .reasonReference MÜSSEN nach OR-Logik in der Ausgabe verwendet werden, d.h. nur eines MUSS geliefert werden können. Weiterhin MÜSSEN beide Elemente interpretiert werden können.\n  Begründung zu Must-Support: Konsolidierung mit MII.",
         "mustSupport": true
       },
       {
@@ -1108,6 +1108,12 @@
           }
         ],
         "mustSupport": true
+      },
+      {
+        "id": "MedicationRequest.priorPrescription",
+        "path": "MedicationRequest.priorPrescription",
+        "short": "Vorherige Verordnung bei fortgesetzter Therapie",
+        "comment": "Hinweis: Dieses Feld dient der Referenz auf eine frühere Verordnung, auf deren Basis die aktuelle Verschreibung fortgeführt wird - z.B. bei Folgerezepten.\n\n  Abgrenzung: Im Gegensatz zur Extension 'medicationRequestReplaces', die das Ersetzen einer Verordnung (z.B. bei Unverträglichkeit) abbildet, beschreibt 'priorPrescription' eine Fortführung einer bestehenden Medikation."
       }
     ]
   }

--- a/Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh
+++ b/Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh
@@ -32,9 +32,10 @@ Description: "Dieses Profil ermöglicht die Abbildung von Medikationsverordnunge
   * valueString MS
 * extension[medicationRequestReplaces]
   * ^short = "Welche Medikationsverordnung wird ersetzt?"
-  * ^comment = "Begründung des Must-Support: historische Nachvollziehbarkeit
+  * ^comment = "Begründung des Must-Support: historische Nachvollziehbarkeit ersetzter Verordnungen.
 
-  Hinweis: Welche Medikationsverordnung wird ersetzt?"
+    Hinweis: Diese Extension dient der Abbildung einer Verordnung, die eine vorherige Medikation ersetzt - z.B. bei Unverträglichkeit, mangelnder Wirksamkeit oder Wechsel des Wirkstoffs.
+    Abgrenzung: Im Gegensatz zum Feld 'priorPrescription', das eine Folgeverordnung bei fortgesetzter Therapie beschreibt, kennzeichnet diese Extension eine bewusste Ablösung der ursprünglichen Verordnung."
   * valueReference MS
     * reference MS
 * status MS
@@ -104,7 +105,7 @@ Begründung zu Must-Support: Konsolidierung mit MII Profil: https://www.medizini
   * text MS
 * reasonReference MS
   * ^short = "Grund der Medikation (Referenz)"
-  * ^comment = "  Festlegung zum MS: Die Elemente .reasonCode und .reasonReference MÜSSEN nach OR-Logik in der Ausgabe verwendet werden, d.h. nur eines MUSS geliefert werden können. Weiterhin MÜSSEN beide Elemente interpretiert werden können.
+  * ^comment = "Festlegung zum MS: Die Elemente .reasonCode und .reasonReference MÜSSEN nach OR-Logik in der Ausgabe verwendet werden, d.h. nur eines MUSS geliefert werden können. Weiterhin MÜSSEN beide Elemente interpretiert werden können.
   Begründung zu Must-Support: Konsolidierung mit MII."
   * reference 1..1 MS
     * ^comment = "Begründung des Must-Support: Referenz auf die Diagnose oder Untersuchung, die die Medikation begründet."
@@ -260,6 +261,11 @@ Begründung zu Must-Support: Konsolidierung mit MII Profil: https://www.medizini
   * ^short = "Ersatz zulässig"
   * ^comment = "Begründung des Must-Support: Alignment mit dem (E-)Rezept"
   * allowedBoolean MS
+* priorPrescription 
+  * ^short = "Vorherige Verordnung bei fortgesetzter Therapie"
+  * ^comment = "Hinweis: Dieses Feld dient der Referenz auf eine frühere Verordnung, auf deren Basis die aktuelle Verschreibung fortgeführt wird - z.B. bei Folgerezepten.
+
+  Abgrenzung: Im Gegensatz zur Extension 'medicationRequestReplaces', die das Ersetzen einer Verordnung (z.B. bei Unverträglichkeit) abbildet, beschreibt 'priorPrescription' eine Fortführung einer bestehenden Medikation."
 
 Instance: ExampleISiKMedikationsVerordnung
 InstanceOf: ISiKMedikationsVerordnung

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -6,6 +6,16 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 ## Version 5.0.0-rc1
 
+Datum: tbd
+
+* `improve` ISiKMedikationsVerordnung: Kommentar zu priorPrescription hinzugefügt und Definitionen
+  in den Kommentaren beider Elemente (priorPrescription und extension.medicationRequestReplaces)
+  sprachlich und fachlich überarbeitet. https://github.com/gematik/spec-ISiK-Basismodul/pull/736
+
+---
+
+## Version 5.0.0-rc (Kommentierung)
+
 Mit der Stufe 5 werden alle Technical Corrections der Stufe 4 bindend.
 
 Datum: 09.04.2025


### PR DESCRIPTION
This pull request introduces updates to the `ISiKMedikationsVerordnung` profile to clarify and enhance the documentation of medication-related fields. The changes include improved descriptions for the `medicationRequestReplaces` extension and the addition of a new field, `priorPrescription`, to distinguish between replacing and continuing medication prescriptions.

### Enhancements to field documentation:

* **Clarified `medicationRequestReplaces` field**:
  - Updated the `comment` to provide a more detailed explanation of its purpose, emphasizing its use for documenting the replacement of a previous medication due to reasons such as intolerance or lack of efficacy. It also contrasts this field with `priorPrescription`, which represents continued therapy. (`Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json`, [[1]](diffhunk://#diff-03cebd27efb0450c38aaf3867373715d9ac3544f4dca76ad6d86dee50d91631aL109-R109); `Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh`, [[2]](diffhunk://#diff-996e2e92f8d6912ab071444fcffdde2386959a62da4ad959677c4fdfea76f92dL35-R38)

### Addition of a new field:

* **Introduced `priorPrescription` field**:
  - Added a new field to represent a reference to a prior prescription for continued therapy, such as follow-up prescriptions. The `comment` explicitly differentiates it from `medicationRequestReplaces`, which addresses replacing a prescription. (`Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json`, [[1]](diffhunk://#diff-03cebd27efb0450c38aaf3867373715d9ac3544f4dca76ad6d86dee50d91631aR1111-R1116); `Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh`, [[2]](diffhunk://#diff-996e2e92f8d6912ab071444fcffdde2386959a62da4ad959677c4fdfea76f92dR264-R268)