### PR TITLE
Update checklist - PR_Template_VersionUpgrade.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md
@@ -18,7 +18,7 @@ All jobs with an `x` in the boxes were performed to the best of knowledge.
 - [ ] The GitHub Actions "TC version update" and "CI (FHIR Validation)" finished successfully; release version and date was updated accordingly by release_publish.py (triggered by action)
 - [ ] Eventually, increase the dependency of  Basispofil-de and possibly others (package json and sushi-config) (update to newer Basismodul not needed anymore)
 - [ ] the release notes were reviewed with a person responsible for testing
-- [ ] New Release Notes were created, aligned to the commit history. Possibly, if you want to check the release notes for completeness, check against automatic relesase note generation in GitHub. In Github, go to 
+- [ ] New Release Notes were created, aligned to the commit history. Possibly, if you want to check the release notes for completeness, check against automatic release note generation in GitHub. In Github, go to 
   - _-> Releases_ then _-> Draft a new release_ with the _Modul Name and Version_, then
   - _-> Target the main-Branch_ and _-> enter a new Tag according to the Version_, then click.
   - Click _-> Generate Release notes_ , _-> Adjust them if necessary_ and _-> Copy/Paste the Details in the RealeaseNotes.md_ of the very Branch you want to merge.

--- a/.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md
@@ -16,7 +16,7 @@ All jobs with an `x` in the boxes were performed to the best of knowledge.
 - This PR refers to a versioned Branch with a name and a version number in the form of N.n.n, e.g. "TC_3.2.1".
 - This PR has a clean meaningful commit history. Minor commits or commits without description have been squashed, at the latest now.
 - [ ] The GitHub Actions "TC version update" and "CI (FHIR Validation)" finished successfully; release version and date was updated accordingly by release_publish.py (triggered by action)
-- [ ] Eventually, increase the dependency of  Basispofil-de and possibly others (package json and sushi-config) (update to newer Basismodul not needed anymore)
+- [ ] Eventually, increase the dependency of  Basispofil-de and possibly others (package.json and sushi-config) (update to newer Basismodul not needed anymore)
 - [ ] the release notes were reviewed with a person responsible for testing
 - [ ] New Release Notes were created, aligned to the commit history. Possibly, if you want to check the release notes for completeness, check against automatic release note generation in GitHub. In Github, go to 
   - _-> Releases_ then _-> Draft a new release_ with the _Modul Name and Version_, then

--- a/.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md
@@ -15,11 +15,10 @@ All jobs with an `x` in the boxes were performed to the best of knowledge.
 <!--- Lets check everything before we continue. -->
 - This PR refers to a versioned Branch with a name and a version number in the form of N.n.n, e.g. "TC_3.2.1".
 - This PR has a clean meaningful commit history. Minor commits or commits without description have been squashed, at the latest now.
-- The GitHub Actions "TC version update" and "CI (FHIR Validation)" finished successfully; release version and date was updated accordingly by release_publish.py (triggered by action)
-- Eventually, increase the dependency of to newer Basis Modul and Basispofil-de and possibly others (package json and sushi-config)
-- [ ] Update IG folder name to current verion (e.g. guide\Implementierungsleitfaden-...-4.0.3)
+- [ ] The GitHub Actions "TC version update" and "CI (FHIR Validation)" finished successfully; release version and date was updated accordingly by release_publish.py (triggered by action)
+- [ ] Eventually, increase the dependency of  Basispofil-de and possibly others (package json and sushi-config) (update to newer Basismodul not needed anymore)
 - [ ] the release notes were reviewed with a person responsible for testing
-- [ ] New Release Notes were created, alined to the commit history. Possibly, if you want to check the release notes for completeness, check against automatic relesase note generation in GitHub. In Github, go to 
+- [ ] New Release Notes were created, aligned to the commit history. Possibly, if you want to check the release notes for completeness, check against automatic relesase note generation in GitHub. In Github, go to 
   - _-> Releases_ then _-> Draft a new release_ with the _Modul Name and Version_, then
   - _-> Target the main-Branch_ and _-> enter a new Tag according to the Version_, then click.
   - Click _-> Generate Release notes_ , _-> Adjust them if necessary_ and _-> Copy/Paste the Details in the RealeaseNotes.md_ of the very Branch you want to merge.


### PR DESCRIPTION
This pull request updates the version upgrade template for pull requests in `.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.md`. The changes improve clarity and ensure consistency in the checklist items for version updates.

Updates to checklist items:

* Added a checkbox format for verifying GitHub Actions completion and clarified that updating to newer Basismodul is no longer required. (`[.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.mdL18-R21](diffhunk://#diff-8ec9591ce39c636e4c0b2c98bf4d285d188aa88664e46437d464cdf75c5ba61aL18-R21)`)
* Improved wording for release notes creation instructions, including alignment with commit history and guidance on using GitHub's automatic release note generation feature. (`[.github/PULL_REQUEST_TEMPLATE/PR_Template_VersionUpgrade.mdL18-R21](diffhunk://#diff-8ec9591ce39c636e4c0b2c98bf4d285d188aa88664e46437d464cdf75c5ba61aL18-R21)`)