### PR TITLE
Update dependencies to versions Firely: v0.6.29, Sushi: 3.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           cat validator/advisor.json
 
       - name: Firely.Terminal (GitHub Actions)
-        uses: FirelyTeam/firely-terminal-pipeline@v0.6.28
+        uses: FirelyTeam/firely-terminal-pipeline@v0.6.29
         with:
           PATH_TO_CONFORMANCE_RESOURCES: Resources/fsh-generated/resources/
           DOTNET_VALIDATION_ENABLED: false


### PR DESCRIPTION
This PR updates the dependencies to versions Firely: v0.6.29 and Sushi: 3.16.0.