### PR TITLE
Deactivate action for FHIR quality control workflow

### DIFF
--- a/.github/workflows/fhir-quality-control.yml
+++ b/.github/workflows/fhir-quality-control.yml
@@ -1,9 +1,6 @@
 name: Check FHIR Quality Control
 
 on:
-  pull_request:
-    branches:
-      - '*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the pull request trigger from the FHIR quality control workflow and update documentation accordingly.

Before activating again false positives should be handled. see suppression file here: https://github.com/gematik/spec-ISiK-Basismodul/pull/788/files