### PR TITLE
Abschnitt für Allgemeine Hinweise zum Umgang mit fehlenden Daten und Austausch von Informationen im ISiK-Kontext ohne Patienten-Informationen hinzugefügt

### DIFF
--- a/guides/Basis-5/Einfuehrung/Festlegungen/Patient-Besuch-Kontext.md
+++ b/guides/Basis-5/Einfuehrung/Festlegungen/Patient-Besuch-Kontext.md
@@ -41,4 +41,82 @@ Ungeachtet der serverseitigen Implementierungsvariante, können Clients stets ei
 | **Warnung**
 <img src="https://raw.githubusercontent.com/gematik/spec-ISiK-Basismodul/refs/heads/archive-stable-pics-etc/Material/piktogramme/Ampel%20auf%20Rot_Blau_gematik.svg" alt="gematik logo" width="75"/> |  **Gefahr fehlerhafter Zuordnung:** Die manuelle Auswahl von Patienten- und Fallkontext durch einen Benutzer ist fehleranfällig. Clients müssen geeignete Vorkehrungen und Plausibilitätsprüfungen implementieren um Falschzuordnungen zu verhindern.|
 
+### Austausch von Informationen im ISiK-Kontext ohne Patienten-Informationen
+
+Die sichere und zweckgebundene Übertragung von Gesundheitsdaten ist ein zentrales Ziel der ISiK-Spezifikation. Der Schwerpunkt liegt hierbei insbesondere auf dem Datenaustausch in den unter {{pagelink:ImplementationGuide-markdown-Motivation}} beschriebenen Anwendungsszenarien. Für diese ist, wie zuvor ausgeführt, in der Regel ein Patientenkontext erforderlich.
+
+Eine Übertragung ohne identifizierende Patienteninformationen ist jedoch nicht ausgeschlossen und kann im Rahmen der ISiK-Standards ebenfalls umgesetzt werden. Technisch erfolgt dies wie folgt:
+
+1. Es wird eine ISiK-konforme Patient-Ressource erzeugt, wobei die verpflichtenden Elemente gemäß Profildefinition (das heißt mit Kardinalität 1..1 beziehungsweise 1..*) befüllt werden müssen. Zu beachten ist, dass dies für jedes Feld erfolgen muss, das gemäß Profildefinition eine verpflichtende Kardinalität aufweist, insbesondere dann, wenn untergeordnete (Child-)Elemente dieser Felder selbst wiederum verpflichtend sind.
+
+2. Felder, deren Inhalte entweder nicht vorliegen oder aus datenschutzrechtlichen Gründen nicht übermittelt werden dürfen, werden mit einer [data-absent-reason Extension](https://hl7.org/fhir/extensions/StructureDefinition-data-absent-reason.html) versehen.
+
+3. Die data-absent-reason Extension wird mit den Codes "unknown" oder "masked" belegt, um das Fehlen datenschutzkritischer Inhalte explizit zu kennzeichnen.
+
+Diese Vorgehensweise ermöglicht eine formell gültige und zugleich datenschutzkonforme Übertragung strukturierter Informationen, auch ohne Bezug zu einer identifizierbaren Person.
+
+Beispiel für eine Patient-Ressource ohne identifizierende Patienteninformationen:
+
+```json
+{
+  "resourceType": "Patient",
+  "id": "anonymized-isik-patient",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://example.org/fhir/sid/patient-id",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical record number"
+          }
+        ]
+      },
+      "_value": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode": "masked"
+          }
+        ]
+      }
+    }
+  ],
+  "name": [
+    {
+      "use": "official",
+      "_family": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode": "masked"
+          }
+        ]
+      },
+      "_given": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "masked"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "gender": "unknown",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "unknown"
+      }
+    ]
+  },
+  ...
+```
+
 

--- a/guides/Basis-5/Einfuehrung/Festlegungen/Patient-Besuch-Kontext.md
+++ b/guides/Basis-5/Einfuehrung/Festlegungen/Patient-Besuch-Kontext.md
@@ -52,6 +52,8 @@ Eine Übertragung ohne identifizierende Patienteninformationen ist jedoch nicht 
 2. Felder, deren Inhalte entweder nicht vorliegen oder aus datenschutzrechtlichen Gründen nicht übermittelt werden dürfen, werden mit einer [data-absent-reason Extension](https://hl7.org/fhir/extensions/StructureDefinition-data-absent-reason.html) versehen.
 
 3. Die data-absent-reason Extension wird mit den Codes "unknown" oder "masked" belegt, um das Fehlen datenschutzkritischer Inhalte explizit zu kennzeichnen.
+Der Code "unknown" kennzeichnet dabei das generelle Fehlen einer Information aufgrund ihrer Abwesenheit – z. B. weil sie (noch) nicht erhoben oder dokumentiert wurde.
+Der Code "masked" kennzeichnet hingegen, dass die Information zwar vorhanden, jedoch aus Datenschutzgründen unterdrückt wurde.
 
 Diese Vorgehensweise ermöglicht eine formell gültige und zugleich datenschutzkonforme Übertragung strukturierter Informationen, auch ohne Bezug zu einer identifizierbaren Person.
 

--- a/guides/Basis-5/Einfuehrung/Festlegungen/UebergreifendeFestlegungen_UmgangFehlendeDaten.page.md
+++ b/guides/Basis-5/Einfuehrung/Festlegungen/UebergreifendeFestlegungen_UmgangFehlendeDaten.page.md
@@ -3,7 +3,7 @@ topic: UebergreifendeFestlegungen-UmgangMitFehlendenDaten
 ---
 ## Allgemeine Hinweise zum Umgang mit fehlenden Daten
 In bestimmten Situationen können Informationen zu einem Datenelement fehlen, ohne dass das Quellsystem den Grund dafür kennt.
-Wenn das betroffene Datenelement eine minimale Kardinalität von 0 hat, also optional ist, auch wenn es als Must Support gekennzeichnet ist, sollte es aus der Ressource weggelassen werden. Handelt es sich hingegen um ein obligatorisches Element mit einer minimalen Kardinalität größer als 0, muss es trotzdem in der Ressource enthalten sein, selbst wenn keine Werte vorliegen. Für solche Fälle wird nachfolgend ein standardisiertes Vorgehen zusammengefasst:
+Wenn das betroffene Datenelement eine minimale Kardinalität von 0 hat, also optional ist, auch wenn es als Must Support gekennzeichnet ist, sollte es aus der Ressource weggelassen werden. Handelt es sich hingegen um ein obligatorisches Element mit einer minimalen Kardinalität größer als 0, muss es trotzdem in der Ressource enthalten sein, selbst wenn keine Werte vorliegen. Für solche Fälle wird nachfolgend ein einheitliches Vorgehen im Sinne einer Best Practice zusammengefasst:
 
 1. Nicht-kodierte Datenelemente
 

--- a/guides/Basis-5/Einfuehrung/Festlegungen/UebergreifendeFestlegungen_UmgangFehlendeDaten.page.md
+++ b/guides/Basis-5/Einfuehrung/Festlegungen/UebergreifendeFestlegungen_UmgangFehlendeDaten.page.md
@@ -1,0 +1,46 @@
+---
+topic: UebergreifendeFestlegungen-UmgangMitFehlendenDaten
+---
+## Allgemeine Hinweise zum Umgang mit fehlenden Daten
+In bestimmten Situationen können Informationen zu einem Datenelement fehlen, ohne dass das Quellsystem den Grund dafür kennt.
+Wenn das betroffene Datenelement eine minimale Kardinalität von 0 hat, also optional ist, auch wenn es als Must Support gekennzeichnet ist, sollte es aus der Ressource weggelassen werden. Handelt es sich hingegen um ein obligatorisches Element mit einer minimalen Kardinalität größer als 0, muss es trotzdem in der Ressource enthalten sein, selbst wenn keine Werte vorliegen. Für solche Fälle wird nachfolgend ein standardisiertes Vorgehen zusammengefasst:
+
+1. Nicht-kodierte Datenelemente
+
+* Verwende die [DataAbsentReason]((https://hl7.org/fhir/extensions/StructureDefinition-data-absent-reason.html)) Extension innerhalb des jeweiligen Datentyps.
+* Nutze den Code ``unknown``, wenn der Wert erwartet wird, aber nicht bekannt ist.
+
+Beispiel: Eine Patient-Ressource, in der kein Name verfügbar ist:
+
+```json
+{
+  "resourceType": "Patient",
+  ...
+  "name": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "unknown"
+        }
+      ]
+    }
+  ],
+  "telecom": ...
+}
+```
+
+2. Kodierte Datenelemente
+
+Bei Bindings mit „example“, „preferred“ oder „extensible“ (für CodeableConcept oder Coding) gilt:
+
+* Wenn das Quellsystem nur Freitext, aber keinen Code kennt, wird lediglich das Textelement verwendet.
+* Bei Coding-Typen wird der Text über das display-Element abgebildet.
+* Liegt weder ein Code noch ein Text vor:
+    * Verwende nach Möglichkeit einen geeigneten „unknown“-Code aus dem zugehörigen ValueSet.
+    * Falls das ValueSet keinen passenden Code enthält, verwende den Code unknown aus dem DataAbsentReason-CodeSystem.
+
+Bei Bindings mit „required“ (für CodeableConcept, Coding oder code):
+
+Verwende, wenn möglich, einen „unknown“-Code aus dem zugewiesenen ValueSet.
+Falls das ValueSet keinen solchen Code bietet, muss ein anderer gültiger Code aus dem ValueSet verwendet werden. Andernfalls ist die Ressource nicht konform zur Spezifikation.

--- a/guides/Basis-5/Einfuehrung/Festlegungen/toc.yaml
+++ b/guides/Basis-5/Einfuehrung/Festlegungen/toc.yaml
@@ -16,3 +16,5 @@
   filename: UebergreifendeFestlegungen_Rest.page.md
 - name: Herstellung von Patienten- und Besuchskontext
   filename: Patient-Besuch-Kontext.md
+- name: Umgang mit fehlenden Daten
+  filename: UebergreifendeFestlegungen_UmgangFehlendeDaten.page.md

--- a/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
@@ -9,6 +9,12 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von Releases. Die dritte Ziffer Y (Release x.0.y) bezeichnet eine technische Korrektur und versioniert kleinere Änderungen (Packages) während eines Jahres, z. B. 1.0.1.
 
+## Version 5.0.1
+
+Datum: XX.XX.2025
+
+* `improve` Allgemeine Hinweise zum Umgang mit fehlenden Daten und Austausch von Informationen im ISiK-Kontext ohne Patienten-Informationen hinzugefügt
+
 ## Version 5.0.0
 
 Datum: 26.06.2025


### PR DESCRIPTION
Fixes https://service.gematik.de/browse/PTDATA-1545