### PR TITLE
Stufe 5 - Termin - add rule on error code

### DIFF
--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementTerminRepositoryRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementTerminRepositoryRolle.json
@@ -292,7 +292,7 @@
               "name": "status",
               "definition": "http://hl7.org/fhir/SearchParameter/Slot-status",
               "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Slot?status=free&schedule=Schedule/ISiKTerminExample`\n        `GET [base]/Slot?status=free&schedule.actor:Practitioner.name=Musterarzt`    \n        **Anwendungshinweis:**   \n        Der Suchparameter `status` MUSS in Kombination ('&') mit dem Parameter `schedule` unterstützt werden. \n        Diese Abfrage KANN entweder eine direkte Angabe einer Referenz oder eine Angabe von weiteren Chaining-Parametern sein.\n        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden.  \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Slot?status=free&schedule=Schedule/ISiKTerminExample`\n        `GET [base]/Slot?status=free&schedule.actor:Practitioner.name=Musterarzt`    \n        **Anwendungshinweis:**   \n        Der Suchparameter `status` MUSS in Kombination ('&') mit dem Parameter `schedule` unterstützt werden. \n        Diese Abfrage KANN entweder eine direkte Angabe einer Referenz oder eine Angabe von weiteren Chaining-Parametern sein.\n        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden. Falls der Parameter nicht alleinstehend unterstützt wird, dann MUSS der Server einen Fehler-Code 422 (Unprocessable Entity) zurückgeben, falls ein Client den Parameter alleinstehend verwendet.\n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
             },
             {
               "extension": [

--- a/Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh
+++ b/Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh
@@ -117,7 +117,7 @@ Usage: #definition
         **Anwendungshinweis:**   
         Der Suchparameter `status` MUSS in Kombination ('&') mit dem Parameter `schedule` unterstützt werden. 
         Diese Abfrage KANN entweder eine direkte Angabe einer Referenz oder eine Angabe von weiteren Chaining-Parametern sein.
-        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden. Falls der Parameter nicht alleinstehend unterstützt wird, dann MUSS der Server einen Fehler Code 422 (Unprocessable Entity) zurückgeben.
+        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden. Falls der Parameter nicht alleinstehend unterstützt wird, dann MUSS der Server einen Fehler Code 422 (Unprocessable Entity) zurückgeben, falls ein Client den Parameter alleinstehend verwendet.
         Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  " 
     * searchParam[+]
       * insert Expectation (#SHALL) 

--- a/Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh
+++ b/Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh
@@ -117,7 +117,7 @@ Usage: #definition
         **Anwendungshinweis:**   
         Der Suchparameter `status` MUSS in Kombination ('&') mit dem Parameter `schedule` unterstützt werden. 
         Diese Abfrage KANN entweder eine direkte Angabe einer Referenz oder eine Angabe von weiteren Chaining-Parametern sein.
-        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden.  
+        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden. Falls der Parameter nicht alleinstehend unterstützt wird, dann MUSS der Server einen Fehler Code 422 (Unprocessable Entity) zurückgeben.
         Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  " 
     * searchParam[+]
       * insert Expectation (#SHALL) 

--- a/Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh
+++ b/Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh
@@ -117,7 +117,7 @@ Usage: #definition
         **Anwendungshinweis:**   
         Der Suchparameter `status` MUSS in Kombination ('&') mit dem Parameter `schedule` unterstützt werden. 
         Diese Abfrage KANN entweder eine direkte Angabe einer Referenz oder eine Angabe von weiteren Chaining-Parametern sein.
-        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden. Falls der Parameter nicht alleinstehend unterstützt wird, dann MUSS der Server einen Fehler Code 422 (Unprocessable Entity) zurückgeben, falls ein Client den Parameter alleinstehend verwendet.
+        Der Suchparameter MUSS NICHT alleinstehend unterstützt werden. Falls der Parameter nicht alleinstehend unterstützt wird, dann MUSS der Server einen Fehler-Code 422 (Unprocessable Entity) zurückgeben, falls ein Client den Parameter alleinstehend verwendet.
         Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  " 
     * searchParam[+]
       * insert Expectation (#SHALL) 

--- a/guides/Terminplanung-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Terminplanung-5/Einfuehrung/ReleaseNotes.page.md
@@ -10,7 +10,7 @@ Datum: tbd.
 
 * `improve` Hinweis zur Handhabung von Create-Interaktionen hinzugefügt https://github.com/gematik/spec-ISiK-Basismodul/pull/792
 * `improve` Klarstellung zur Fallunterscheidung bei der Patienteninstanz-Übergabe und Begründung sowie Hinweis hinzugefügt https://github.com/gematik/spec-ISiK-Basismodul/pull/793
-* `improve` Klarstellung zum Fehlercode bei nicht unterstütztem alleinstehendem Parameter 'start' 
+* `improve` Klarstellung zum Fehlercode bei nicht unterstütztem alleinstehendem Parameter 'start' https://github.com/gematik/spec-ISiK-Basismodul/pull/797
 
 
 ## Version 5.0.0

--- a/guides/Terminplanung-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Terminplanung-5/Einfuehrung/ReleaseNotes.page.md
@@ -10,6 +10,7 @@ Datum: tbd.
 
 * `improve` Hinweis zur Handhabung von Create-Interaktionen hinzugefügt https://github.com/gematik/spec-ISiK-Basismodul/pull/792
 * `improve` Klarstellung zur Fallunterscheidung bei der Patienteninstanz-Übergabe und Begründung sowie Hinweis hinzugefügt https://github.com/gematik/spec-ISiK-Basismodul/pull/793
+* `improve` Klarstellung zum Fehlercode bei nicht unterstütztem alleinstehendem Parameter 'start' 
 
 
 ## Version 5.0.0


### PR DESCRIPTION
This pull request includes updates to clarify error handling and improve documentation in the ISiK Terminplanung specification. The changes focus on specifying server behavior for unsupported parameters.

### Clarifications to error handling:

* [`Resources/input/fsh/Terminplanung/Rollen/ISiKCapabilityStatementTerminRepositoryRolle.fsh`](diffhunk://#diff-91cbc95c8f92c4ab2fd94bed1be1c9dd78210e0f130bf3db0994b4af119d0787L120-R120): Updated the definition of the `status` search parameter to specify that if the parameter is not supported alone, the server MUST return an HTTP 422 (Unprocessable Entity) error code.