### PR TITLE
Stufe 5/alle/fix/validation ptdata 1539

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,23 +90,24 @@ jobs:
           filters: |
             # Struktur: fileName|messageId|detailsWildcard|location
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Linksatrialer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
+            #Observation-Linksatrialer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM|*minimum required = 1*|Observation
+            #Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM|*minimum required = 1*|Observation
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_SLICE|*matching slice is required*|Observation
+            #Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_SLICE|*matching slice is required*|Observation
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
+            #Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Pulmonalarterieller-Blutdruck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
+            #Observation-Pulmonalarterieller-Blutdruck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Rechtsatrialer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
+            #Observation-Rechtsatrialer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
             # Error because of wrong magic loinc code/bug in java validator
-            Observation-Rechtsventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
+            #Observation-Rechtsventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
             # Error because of the java validator not supporting version "*"
-            Procedure-Appendektomie.json||*"http://fhir.de/CodeSystem/bfarm/ops"*|Procedure.code.coding[1].version
+            #Procedure-Appendektomie.json||*"http://fhir.de/CodeSystem/bfarm/ops"*|Procedure.code.coding[1].version
             # Error caused by a bug in the java validator
-            StructureDefinition-ISiKKontaktGesundheitseinrichtung.json|Unknown_Code_in_Version|Unknown code ''*|
+            #StructureDefinition-ISiKKontaktGesundheitseinrichtung.json|Unknown_Code_in_Version|Unknown code ''*|
+
       - name: Validate Resource Status
         uses: patrick-werner/fhir-resource-status-check@1.2.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,24 +89,6 @@ jobs:
           include: errors
           filters: |
             # Struktur: fileName|messageId|detailsWildcard|location
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Linksatrialer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM|*minimum required = 1*|Observation
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_SLICE|*matching slice is required*|Observation
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Linksventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Pulmonalarterieller-Blutdruck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Rechtsatrialer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
-            # Error because of wrong magic loinc code/bug in java validator
-            #Observation-Rechtsventrikulaerer-Druck.json|VALIDATION_VAL_PROFILE_MINIMUM_MAGIC|*magic LOINC code*|Observation.code
-            # Error because of the java validator not supporting version "*"
-            #Procedure-Appendektomie.json||*"http://fhir.de/CodeSystem/bfarm/ops"*|Procedure.code.coding[1].version
-            # Error caused by a bug in the java validator
-            #StructureDefinition-ISiKKontaktGesundheitseinrichtung.json|Unknown_Code_in_Version|Unknown code ''*|
 
       - name: Validate Resource Status
         uses: patrick-werner/fhir-resource-status-check@1.2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,15 +50,6 @@ jobs:
         uses: actions/checkout@v4
         if: github.event_name != 'pull_request'
 
-      # can be deleted after https://github.com/hapifhir/org.hl7.fhir.core/pull/1990 is merged (adding json5 support)
-      - name: Strip pure comment lines
-        run: |
-          # nur Zeilen löschen, die mit optionalem Whitespace und dann // anfangen
-          sed -i '/^[[:space:]]*\/\//d' validator/advisor.json
-          # leere Zeilen aufräumen
-          sed -i '/^[[:space:]]*$/d' validator/advisor.json
-          cat validator/advisor.json
-
       - name: Firely.Terminal (GitHub Actions)
         uses: FirelyTeam/firely-terminal-pipeline@v0.7.4
         with:

--- a/validator/advisor.json
+++ b/validator/advisor.json
@@ -55,6 +55,13 @@
     // filters expected information messages for the usage of wrong fullUrl in a Bundle.
     "BUNDLE_BUNDLE_POSSIBLE_MATCH_WRONG_FU@Bundle.entry[0].resource/*Parameters/SubscriptionNotification*/.parameter[5].part[2].value.ofType(Reference)",
     // filters expected information messages for the usage of non-existing ValueSets.
-    "Terminology_TX_ValueSet_NotFound@Bundle.entry[0].resource/*Parameters/SubscriptionNotification*/.parameter[3].value.ofType(code)"
+    "Terminology_TX_ValueSet_NotFound@Bundle.entry[0].resource/*Parameters/SubscriptionNotification*/.parameter[3].value.ofType(code)",
+    //Filter Bug with coding pattern only containing the system in the java validate (Issue: https://github.com/hapifhir/org.hl7.fhir.core/issues/2108 - can't filter on path, so filtering on message id only)
+    "Unknown_Code_in_Version",
+    //Filter Bug with ignoring the display language '-langage de' (https://github.com/hapifhir/org.hl7.fhir.core/issues/2111 - can't filter on path, so filtering on message id only)
+   "NO_VALID_DISPLAY_FOUND_NONE_FOR_LANG_ERR",
+   // filters error for missing OPS CodeSystem
+   "Terminology_TX_Confirm_4a@Procedure.code.coding[1]" 
+
   ]
 }


### PR DESCRIPTION
This pull request primarily focuses on cleaning up unused code and improving the handling of known validation issues in the workflow and configuration files. The changes include the removal of outdated scripts, commenting out specific validation filters, and adding new filters for known bugs in the validation process.

### Workflow cleanup and validation improvements:

- **Removal of outdated scripts**: Deleted the script that strips pure comment lines from `validator/advisor.json` in the GitHub Actions workflow, as it is no longer needed following the addition of JSON5 support in the upstream repository. (`.github/workflows/main.yml`, [.github/workflows/main.ymlL53-L61](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L53-L61))
- **Commenting out validation filters**: Commented out specific validation filters in the workflow configuration to suppress errors caused by known issues in the Java validator, such as incorrect handling of LOINC codes and unsupported version fields. (`.github/workflows/main.yml`, [.github/workflows/main.ymlL102-R110](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L102-R110))

### Updates to `validator/advisor.json`:

- **Addition of new filters**: Added filters to suppress errors caused by known bugs in the Java validator, including issues with coding patterns containing only the system, display language handling, and missing OPS CodeSystem. (`validator/advisor.json`, [validator/advisor.jsonL58-R65](diffhunk://#diff-e14c133e05aa8cf64216c1bc2b9ff8fd5015d72353ac32df7ce85b5edd72ff34L58-R65))