### PR TITLE
fix: correct typo in documentation link formatting in ReleaseNotes

### DIFF
--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -8,7 +8,8 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 Datum: tbd
 
-* `documentation` Link due Dosierungsbeispielen im IG Medikation https://github.com/gematik/spec-ISiK-Basismodul/pull/882
+* `documentation` Link zu Dosierungsbeispielen im IG
+  Medikation https://github.com/gematik/spec-ISiK-Basismodul/pull/882
 * `documentation` Erläuterung zur Nutzung von MedicationRequest.status für die Umsetzung asynchroner Prüfung im empfangenden System  https://github.com/gematik/spec-ISiK-Basismodul/pull/807
 
 * `documentation` Erläuterung für die Umsetzung der Pausierung einer Medikation https://github.com/gematik/spec-ISiK-Basismodul/pull/803


### PR DESCRIPTION
This pull request makes a minor documentation improvement by clarifying the wording of a release note entry and improving its formatting. No functional or structural changes are included.