### PR TITLE
Update Versicherungsverhältnis to old specification

### DIFF
--- a/Resources/fsh-generated/resources/Bundle-Szenario1.json
+++ b/Resources/fsh-generated/resources/Bundle-Szenario1.json
@@ -147,24 +147,24 @@
             "display": "TKKG"
           }
         ],
-        "status": "active",
-        "beneficiary": {
-          "reference": "Patient/SZ1Patient"
-        },
         "subscriber": {
-          "reference": "RelatedPerson/SZ1Mutter",
           "identifier": {
             "type": {
               "coding": [
                 {
-                  "code": "KVZ10",
-                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis"
+                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+                  "code": "KVZ10"
                 }
               ]
             },
             "system": "http://fhir.de/sid/gkv/kvid-10",
             "value": "A987654321"
-          }
+          },
+          "reference": "RelatedPerson/SZ1Mutter"
+        },
+        "status": "active",
+        "beneficiary": {
+          "reference": "Patient/SZ1Patient"
         }
       }
     },

--- a/Resources/fsh-generated/resources/Bundle-Szenario2.json
+++ b/Resources/fsh-generated/resources/Bundle-Szenario2.json
@@ -315,11 +315,23 @@
             "display": "BKK für Testpatienten"
           }
         ],
-        "status": "active",
-        "beneficiary": {
+        "subscriber": {
+          "identifier": {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+                  "code": "KVZ10"
+                }
+              ]
+            },
+            "system": "http://fhir.de/sid/gkv/kvid-10",
+            "value": "A222222222"
+          },
           "reference": "Patient/SZ2Patient"
         },
-        "subscriber": {
+        "status": "active",
+        "beneficiary": {
           "reference": "Patient/SZ2Patient"
         }
       }

--- a/Resources/fsh-generated/resources/Coverage-SZ1VersicherungGesetzlich.json
+++ b/Resources/fsh-generated/resources/Coverage-SZ1VersicherungGesetzlich.json
@@ -31,23 +31,23 @@
       "display": "TKKG"
     }
   ],
-  "status": "active",
-  "beneficiary": {
-    "reference": "Patient/SZ1Patient"
-  },
   "subscriber": {
-    "reference": "RelatedPerson/SZ1Mutter",
     "identifier": {
       "type": {
         "coding": [
           {
-            "code": "KVZ10",
-            "system": "http://fhir.de/CodeSystem/identifier-type-de-basis"
+            "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+            "code": "KVZ10"
           }
         ]
       },
       "system": "http://fhir.de/sid/gkv/kvid-10",
       "value": "A987654321"
-    }
+    },
+    "reference": "RelatedPerson/SZ1Mutter"
+  },
+  "status": "active",
+  "beneficiary": {
+    "reference": "Patient/SZ1Patient"
   }
 }

--- a/Resources/fsh-generated/resources/Coverage-SZ2VersicherungGesetzlich.json
+++ b/Resources/fsh-generated/resources/Coverage-SZ2VersicherungGesetzlich.json
@@ -31,11 +31,23 @@
       "display": "BKK für Testpatienten"
     }
   ],
-  "status": "active",
-  "beneficiary": {
+  "subscriber": {
+    "identifier": {
+      "type": {
+        "coding": [
+          {
+            "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+            "code": "KVZ10"
+          }
+        ]
+      },
+      "system": "http://fhir.de/sid/gkv/kvid-10",
+      "value": "A222222222"
+    },
     "reference": "Patient/SZ2Patient"
   },
-  "subscriber": {
+  "status": "active",
+  "beneficiary": {
     "reference": "Patient/SZ2Patient"
   }
 }

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKVersicherungsverhaeltnisGesetzlich.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKVersicherungsverhaeltnisGesetzlich.json
@@ -85,7 +85,43 @@
         "id": "Coverage.subscriber.reference",
         "path": "Coverage.subscriber.reference",
         "comment": "Die Verlinkung auf eine Patienten- oder RelatedPerson-Ressource dient der technischen Zuordnung der Dokumentation zu einem Patienten/Angehörigen \n    und ermöglicht wichtige API-Funktionen wie verkettete Suche, (Reverse-)Include etc.",
+        "mustSupport": true
+      },
+      {
+        "id": "Coverage.subscriber.identifier",
+        "path": "Coverage.subscriber.identifier",
+        "short": "Lebenslange Krankenversichertennummer der Hauptversicherten",
+        "comment": "Die als 'KVZ10' kodierte Versichertennummer ist der 10-stellige, \n      unveränderbare Teil der Versichertennummer, \n      der lesbar auf die Elektronische Gesundheitskarte aufgedruckt ist.\n      Er gilt für alle Krankenversichertennummern, \n      unabhängig davon, ob es sich um GKV, PKV oder Sonderkostenträger handelt.  \n      **Weitere Hinweise:** siehe [Deutschen Basisprofile](https://simplifier.net/guide/leitfaden-de-basis-r4/ig-markdown-LebenslangeKrankenversichertennummer10-stelligeKVID-Identifier?version=current)",
         "min": 1,
+        "type": [
+          {
+            "code": "Identifier",
+            "profile": [
+              "http://fhir.de/StructureDefinition/identifier-kvid-10"
+            ]
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "Coverage.subscriber.identifier.system",
+        "path": "Coverage.subscriber.identifier.system",
+        "short": "Namensraum der Versichertennummer",
+        "comment": "Hier ist stets der Wert `http://fhir.de/sid/gkv/kvid-10` anzugeben.  \n      **Begründung Pflichtfeld:** `system` stellt in Kombination mit `value` die Eindeutigkeit eines Identifiers sicher.",
+        "mustSupport": true
+      },
+      {
+        "id": "Coverage.subscriber.identifier.value",
+        "path": "Coverage.subscriber.identifier.value",
+        "short": "Lebenslange Krankenversichertennummer",
+        "comment": "Der 10-stellige, unveränderbare Teil der Versichertennummer.",
+        "mustSupport": true
+      },
+      {
+        "id": "Coverage.subscriber.display",
+        "path": "Coverage.subscriber.display",
+        "short": "Name des Hauptversicherten",
+        "comment": "**Begründung MS:** Da das die Versichertennummer nicht zur Darstellung für den Anwender geeignet ist, \n    sollte ergänzend der Name des Versicherten angegeben werden.",
         "mustSupport": true
       },
       {

--- a/Resources/input/fsh/Basis/Beispiel-Szenario-2.fsh
+++ b/Resources/input/fsh/Basis/Beispiel-Szenario-2.fsh
@@ -89,6 +89,11 @@ Usage: #example
 * type = $versicherungsart-de-basis#GKV
 * beneficiary = Reference(SZ2Patient)
 * subscriber = Reference(SZ2Patient)
+* subscriber
+  * identifier
+    * type = $identifier-type-de-basis#KVZ10
+    * system = "http://fhir.de/sid/gkv/kvid-10"
+    * value = "A222222222"  
 * payor
   * identifier
     * type = $v2-0203#XX

--- a/Resources/input/fsh/Basis/ISiKVersicherungsverhaeltnisGesetzlich.fsh
+++ b/Resources/input/fsh/Basis/ISiKVersicherungsverhaeltnisGesetzlich.fsh
@@ -52,10 +52,10 @@ Hinweise zu Inkompatibilitäten können über die [Portalseite](https://service.
 
   **Hinweis:** Die Angabe der VersichertenID des Hauptversicherten in `subscriber.identifier` ist verpflichtend. 
   Weitere Angaben zum Versicherten (Name, Adresse) können in einer `RelatedPerson`-Resource hinterlegt werden, auf die hier referenziert wird."
-  * reference 1.. MS
+  * reference MS
     * ^comment = "Die Verlinkung auf eine Patienten- oder RelatedPerson-Ressource dient der technischen Zuordnung der Dokumentation zu einem Patienten/Angehörigen 
     und ermöglicht wichtige API-Funktionen wie verkettete Suche, (Reverse-)Include etc."
- /*  * identifier 1.. MS // Das MS Flag dient der Übernahme von 'identifier' aus der Patienten-Instanz.
+  * identifier 1.. MS // Das MS Flag dient der Übernahme von 'identifier' aus der Patienten-Instanz.
   * identifier only IdentifierKvid10
     * ^short = "Lebenslange Krankenversichertennummer der Hauptversicherten"
     * ^comment = "Die als 'KVZ10' kodierte Versichertennummer ist der 10-stellige, 
@@ -75,7 +75,6 @@ Hinweise zu Inkompatibilitäten können über die [Portalseite](https://service.
     * ^short = "Name des Hauptversicherten"
     * ^comment = "**Begründung MS:** Da das die Versichertennummer nicht zur Darstellung für den Anwender geeignet ist, 
     sollte ergänzend der Name des Versicherten angegeben werden."
- */
 * beneficiary MS
   * ^short = "Versicherte Person"
   * ^comment = "Hier handelt es ich konkret um den Patienten, der unter diesem Versicherungsverhältnis behandelt wird."

--- a/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
@@ -39,6 +39,7 @@ Datum: 22.10.2025
 * `improve` Hinweis zur Handhabung von Encounter.location.status bei Verlegungen hinzugefügt https://github.com/gematik/spec-ISiK-Basismodul/pull/881
 * `improve` Die Profile ``ISiKPatient``, ``ÌSiKOrganization``, sowie ``ISiKPersonImGesundheitsberuf`` enthalten nun eine "impose-Profile"-Extension um die Kompabilität mit den entsprechenden [TI-Commons-Profile](https://gemspec.gematik.de/ig/fhir/ti/1.1.1/index.html) zu dokumentieren.
 * `documentation` Hinweise zur Kompabilität des ISiKPatient-Profils zum EPAPatient-Profil der gematik hinzugefügt https://github.com/gematik/spec-ISiK-Basismodul/pull/898
+* `fix` Änderung an Coverage.subscriber.identifier wurde zurückgenommen https://github.com/gematik/spec-ISiK-Basismodul/pull/912
 
 
 


### PR DESCRIPTION
A change that the coverage.subscriber.identifier is not longer specified, is being returned to the old state