### PR TITLE
remove subscription backport profiles

### DIFF
--- a/scripts/QualityAssuranceAutomation/logs/validation-20251106T151809.log
+++ b/scripts/QualityAssuranceAutomation/logs/validation-20251106T151809.log
@@ -1,0 +1,192 @@
+Starte Prüfung in: ../../Resources/fsh-generated/resources
+
+🚫 Unterdrückte Profile (nicht geprüft):
+  - StructureDefinition-BackportSubscriptionNotificationR4Fixed.json  // Alle Backport profile (beginnend mit 'StructureDefinition-Backport...' werden ausgenommen, da hier die wesentlichen Design-Entscheidungen extern erfolgt sind.
+  - StructureDefinition-BackportSubscriptionStatusR4Fixed.json
+  - StructureDefinition-sd-mii-icu-herzzeitvolumen.json  // Alle mii profile (beginnend mit 'StructureDefinition-sd-mii...' werden ausgenommen, da hier die wesentlichen Design-Entscheidungen extern erfolgt sind.
+  - StructureDefinition-sd-mii-icu-ideales-koerpergewicht.json
+  - StructureDefinition-sd-mii-icu-intrakranieller-druck-icp.json
+  - StructureDefinition-sd-mii-icu-koerpergewicht-percentil-altersabhaengig.json
+  - StructureDefinition-sd-mii-icu-koerpergroesse-percentil-altersabhaengig.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-achsel.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-atemwege.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-blut.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-brust.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-brustwirbelsaeule.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-gelenk.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-generisch.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-halswirbelsaeule.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-harnblase.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-kern.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-leiste.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-lendenwirbelsaeule.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-myokard.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-nasal.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-nasen-rachen-raum.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-rektal.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-speiseroehre.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-stirn.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-trommelfell.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-unter-der-zunge.json
+  - StructureDefinition-sd-mii-icu-koerpertemperatur-vaginal.json
+  - StructureDefinition-sd-mii-icu-linksatrialer-druck.json
+  - StructureDefinition-sd-mii-icu-linksventri-herzindex-durch-indikatorverduennung.json
+  - StructureDefinition-sd-mii-icu-linksventri-herzzeitvolumen-durch-indikatorverd.json
+  - StructureDefinition-sd-mii-icu-linksventri-schlagvolumen-durch-indikatorverduennung.json
+  - StructureDefinition-sd-mii-icu-linksventri-schlagvolumenindex-durch-indikatorverd.json
+  - StructureDefinition-sd-mii-icu-linksventrikulaerer-druck.json
+  - StructureDefinition-sd-mii-icu-linksventrikulaerer-herzindex.json
+  - StructureDefinition-sd-mii-icu-linksventrikulaeres-schlagvolumen.json
+  - StructureDefinition-sd-mii-icu-linksventrikulaeres-schlagvolumenindex.json
+  - StructureDefinition-sd-mii-icu-monitoring-und-vitaldaten.json
+  - StructureDefinition-sd-mii-icu-o2saettigung-im-arteriellen-blut-durch-pulsoxymetrie.json
+  - StructureDefinition-sd-mii-icu-o2saettigung-im-blut-postduktal-durch-pulsoxymetrie.json
+  - StructureDefinition-sd-mii-icu-o2saettigung-im-blut-preduktal-durch-pulsoxymetrie.json
+  - StructureDefinition-sd-mii-icu-pulmonalarterieller-blutdruck.json
+  - StructureDefinition-sd-mii-icu-pulmonalarterieller-wedge-druck.json
+  - StructureDefinition-sd-mii-icu-pulmonalvaskulaerer-widerstandsindex.json
+  - StructureDefinition-sd-mii-icu-puls.json
+  - StructureDefinition-sd-mii-icu-sonstige-pulsatile-druecke-generisch.json
+  - StructureDefinition-sd-mii-icu-systemischer-vaskulaerer-widerstandsindex.json
+  - StructureDefinition-sd-mii-icu-zentralvenoeser-blutdruck.json
+
+🧾 Übersicht der Best Practice Fehler pro Ressource:
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKAcceptedRisk.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKBehandlungsziel.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKCapabilityStatementImportsExpectation.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKMedicationRequestReplaces.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKMedicationStatementReplaces.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKMedikationsart.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: 4 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKSelbstmedikation.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKDokumentenSuchergebnisse.json: 2 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKFormularDaten.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKontaktGesundheitseinrichtung.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKLaboruntersuchung.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMDRRelevanzFormularExtension.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsInformation.json: 2 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsListe.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerabreichung.json: 2 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerordnung.json: 2 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationTransaction.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationTransactionResponse.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPersonImGesundheitsberuf.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: 3 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminPriorityExtension.json: 1 Fehler
+  ❌ ❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: 4 Fehler
+
+🚫 Fehler:
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKAcceptedRisk.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKBehandlungsziel.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKCapabilityStatementImportsExpectation.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKMedicationRequestReplaces.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKMedicationStatementReplaces.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKMedikationsart.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes comment für MustSupport-Element 'Extension.extension:Entlassform'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes comment für MustSupport-Element 'Extension.extension:BesondereBehandlung'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes comment für MustSupport-Element 'Extension.extension:BehandlungsergebnisReha'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes comment für MustSupport-Element 'Extension.extension:UnterbrechnungReha'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKSelbstmedikation.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKDokumentenSuchergebnisse.json: Element 'Bundle.total' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKDokumentenSuchergebnisse.json: Fehlendes comment für MustSupport-Element 'Bundle.entry:DocumentReference'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKFormularDaten.json: Fehlendes comment für MustSupport-Element 'QuestionnaireResponse.item'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKontaktGesundheitseinrichtung.json: Fehlendes comment für MustSupport-Element 'Encounter.serviceType'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKLaboruntersuchung.json: Fehlendes comment für MustSupport-Element 'Observation.effective[x]:effectiveDateTime'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMDRRelevanzFormularExtension.json: Element 'Extension.value[x]' mit Kardinalität '1..' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsInformation.json: Fehlendes comment für MustSupport-Element 'MedicationStatement.medication[x]'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsInformation.json: Fehlendes comment für MustSupport-Element 'MedicationStatement.note'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsListe.json: Fehlendes comment für MustSupport-Element 'List.entry'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerabreichung.json: Fehlendes comment für MustSupport-Element 'MedicationAdministration.performer'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerabreichung.json: Fehlendes comment für MustSupport-Element 'MedicationAdministration.note'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerordnung.json: Fehlendes comment für MustSupport-Element 'MedicationRequest.note'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerordnung.json: Fehlendes comment für MustSupport-Element 'MedicationRequest.dispenseRequest'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationTransaction.json: Fehlendes comment für MustSupport-Element 'Bundle.entry'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationTransactionResponse.json: Fehlendes comment für MustSupport-Element 'Bundle.entry'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPersonImGesundheitsberuf.json: Element 'Practitioner.name:Geburtsname' mit Kardinalität '0..1' hat kein mustSupport-Attribut.
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes comment für MustSupport-Element 'Appointment.extension:replaces'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes comment für MustSupport-Element 'Appointment.participant:AkteurMedizinischeBehandlungseinheit'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes comment für MustSupport-Element 'Appointment.participant:Angehoeriger'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminPriorityExtension.json: Fehlendes comment für MustSupport-Element 'Extension.value[x]'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes comment für MustSupport-Element 'Quantity.value'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes comment für MustSupport-Element 'Quantity.unit'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes comment für MustSupport-Element 'Quantity.system'
+❌ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes comment für MustSupport-Element 'Quantity.code'
+
+⚠️ Warnungen:
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes short für MustSupport-Element 'Extension.extension:Entlassform'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes short für MustSupport-Element 'Extension.extension:BesondereBehandlung'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes short für MustSupport-Element 'Extension.extension:BehandlungsergebnisReha'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ExtensionISiKRehaEntlassung.json: Fehlendes short für MustSupport-Element 'Extension.extension:UnterbrechnungReha'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKAlkoholAbusus.json: StructureDefinition.description ist nicht ausgefüllt
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKAMTSBewertung.json: Fehlendes short für MustSupport-Element 'RiskAssessment.status'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKAMTSBewertung.json: Fehlendes short für MustSupport-Element 'RiskAssessment.occurrence[x]:occurrenceDateTime'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKAMTSBewertung.json: Fehlendes short für MustSupport-Element 'RiskAssessment.occurrence[x]:occurrencePeriod'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKAMTSBewertung.json: Fehlendes short für MustSupport-Element 'RiskAssessment.prediction'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKDokumentenSuchergebnisse.json: StructureDefinition.description ist nicht ausgefüllt
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKFormularDaten.json: Fehlendes short für MustSupport-Element 'QuestionnaireResponse.item'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKFormularDefinition.json: StructureDefinition.description ist nicht ausgefüllt
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKalender.json: Fehlendes short für MustSupport-Element 'Schedule.extension:KalenderName'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKalender.json: Fehlendes short für MustSupport-Element 'Schedule.active'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKalender.json: Fehlendes short für MustSupport-Element 'Schedule.serviceType'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKalender.json: Fehlendes short für MustSupport-Element 'Schedule.specialty'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKalender.json: Fehlendes short für MustSupport-Element 'Schedule.actor'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKalender.json: Fehlendes short für MustSupport-Element 'Schedule.actor:Akteur'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKontaktGesundheitseinrichtung.json: Fehlendes short für MustSupport-Element 'Encounter.identifier'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKontaktGesundheitseinrichtung.json: Fehlendes short für MustSupport-Element 'Encounter.type'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKKontaktGesundheitseinrichtung.json: Fehlendes short für MustSupport-Element 'Encounter.serviceType'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKLaboruntersuchung.json: Fehlendes short für MustSupport-Element 'Observation.effective[x]:effectiveDateTime'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKLaboruntersuchung.json: Fehlendes short für MustSupport-Element 'Observation.method'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKLaboruntersuchung.json: Fehlendes short für MustSupport-Element 'Observation.specimen'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsInformation.json: Fehlendes short für MustSupport-Element 'MedicationStatement.medication[x]'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsInformation.json: Fehlendes short für MustSupport-Element 'MedicationStatement.note'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerabreichung.json: Fehlendes short für MustSupport-Element 'MedicationAdministration.performer'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerabreichung.json: Fehlendes short für MustSupport-Element 'MedicationAdministration.note'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerordnung.json: Fehlendes short für MustSupport-Element 'MedicationRequest.note'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedikationsVerordnung.json: Fehlendes short für MustSupport-Element 'MedicationRequest.dispenseRequest'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedizinischeBehandlungseinheit.json: Fehlendes short für MustSupport-Element 'HealthcareService.active'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedizinischeBehandlungseinheit.json: Fehlendes short für MustSupport-Element 'HealthcareService.type'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedizinischeBehandlungseinheit.json: Fehlendes short für MustSupport-Element 'HealthcareService.specialty'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKMedizinischeBehandlungseinheit.json: Fehlendes short für MustSupport-Element 'HealthcareService.name'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPatient.json: Fehlendes short für MustSupport-Element 'Patient.identifier'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPatient.json: Fehlendes short für MustSupport-Element 'Patient.name'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPatient.json: Fehlendes short für MustSupport-Element 'Patient.address'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPersonImGesundheitsberuf.json: Fehlendes short für MustSupport-Element 'Practitioner.identifier'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPersonImGesundheitsberuf.json: Fehlendes short für MustSupport-Element 'Practitioner.name'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKPersonImGesundheitsberuf.json: Fehlendes short für MustSupport-Element 'Practitioner.address'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKRaucherStatus.json: StructureDefinition.description ist nicht ausgefüllt
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKSchwangerschaftErwarteterEntbindungstermin.json: StructureDefinition.description ist nicht ausgefüllt
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKSchwangerschaftsstatus.json: Fehlendes short für MustSupport-Element 'Observation.value[x]:valueCodeableConcept'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKStandortRaum.json: Fehlendes short für MustSupport-Element 'Location.operationalStatus'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.meta'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.extension:replaces'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.status'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.cancelationReason'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.serviceType'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.specialty'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.priority'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.start'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.end'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.slot'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.comment'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.patientInstruction'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.participant'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.participant:AkteurPatient'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.participant:AkteurPersonImGesundheitsberuf'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.participant:AkteurMedizinischeBehandlungseinheit'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTermin.json: Fehlendes short für MustSupport-Element 'Appointment.participant:Angehoeriger'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminblock.json: Fehlendes short für MustSupport-Element 'Slot.schedule'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminblock.json: Fehlendes short für MustSupport-Element 'Slot.status'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminblock.json: Fehlendes short für MustSupport-Element 'Slot.start'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminblock.json: Fehlendes short für MustSupport-Element 'Slot.end'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKTerminPriorityExtension.json: Fehlendes short für MustSupport-Element 'Extension.value[x]'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKVersicherungsverhaeltnisGesetzlich.json: Fehlendes short für MustSupport-Element 'Coverage.type'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKVersicherungsverhaeltnisSelbstzahler.json: Fehlendes short für MustSupport-Element 'Coverage.type'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKVersicherungsverhaeltnisSelbstzahler.json: Fehlendes short für MustSupport-Element 'Coverage.beneficiary'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKVersicherungsverhaeltnisSonstige.json: Fehlendes short für MustSupport-Element 'Coverage.type'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-ISiKVersicherungsverhaeltnisSonstige.json: Fehlendes short für MustSupport-Element 'Coverage.beneficiary'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes short für MustSupport-Element 'Quantity.value'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes short für MustSupport-Element 'Quantity.unit'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes short für MustSupport-Element 'Quantity.system'
+⚠️ ..\..\Resources\fsh-generated\resources\StructureDefinition-MedicationQuantity.json: Fehlendes short für MustSupport-Element 'Quantity.code'
+
+🔖 Log-Datei erstellt unter: logs\validation-20251106T151809.log

--- a/scripts/QualityAssuranceAutomation/suppression.config.json
+++ b/scripts/QualityAssuranceAutomation/suppression.config.json
@@ -1,6 +1,12 @@
 {
   "suppressProfiles": [
-    {
+        {
+  "profile": "StructureDefinition-BackportSubscriptionNotificationR4Fixed.json",
+  "comment": "Alle Subscription-Backport profile (beginnend mit 'StructureDefinition-Backport...' werden ausgenommen, da hier die wesentlichen Design-Entscheidungen extern erfolgt sind."
+},
+{
+  "profile": "StructureDefinition-BackportSubscriptionStatusR4Fixed.json"},
+{
   "profile": "StructureDefinition-sd-mii-icu-herzzeitvolumen.json",
   "comment": "Alle mii profile (beginnend mit 'StructureDefinition-sd-mii...' werden ausgenommen, da hier die wesentlichen Design-Entscheidungen extern erfolgt sind."
 },


### PR DESCRIPTION
Für das QA Skript gilt: Alle Subscription-Backport profile (beginnend mit 'StructureDefinition-Backport...' werden ausgenommen, da hier die wesentlichen Design-Entscheidungen extern erfolgt sind.