### PR TITLE
ci: update ig-publisher.yml to trigger workflows on push events to main release branches

### DIFF
--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -26,6 +26,11 @@ on:
   # Run on pull request events only
   pull_request:
 
+  # Run on pushes to main release branches
+  push:
+    branches:
+      - main-stufe-*
+
   # Allow manual triggering for production builds or testing
   workflow_dispatch:
     inputs:
@@ -183,6 +188,7 @@ jobs:
       # Note: This action supports multiple URLs via capability_statement_urls (JSON array).
       - name: Expand CapabilityStatement
         uses: Gefyra/capabilityStatement-expander@v0
+        if: ${{ toJSON(matrix.capability_statement_urls) != 'null' && toJSON(matrix.capability_statement_urls) != '[]' }}
         with:
           input_directory: ${{ env.SUSHI_INPUT_DIR }}/fsh-generated
           output_directory: ${{ env.IG_PUBLISHER_DIR }}/input/resources
@@ -395,7 +401,7 @@ jobs:
   publish_gate:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       should_publish: ${{ steps.publish_check.outputs.should_publish }}
     steps:
@@ -426,7 +432,7 @@ jobs:
   publish:
     needs: [build, publish_gate]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.publish_gate.outputs.should_publish == 'true'
+    if: needs.publish_gate.outputs.should_publish == 'true' && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     concurrency:
       group: gh-pages-publish
       cancel-in-progress: false


### PR DESCRIPTION
This pull request updates the `ig-publisher.yml` GitHub Actions workflow to improve its flexibility and robustness. The main changes expand the workflow triggers to include pushes to main release branches, refine conditional job execution, and ensure publishing logic applies to all relevant event types.

Workflow trigger enhancements:

* Added support for running the workflow on pushes to any branch matching `main-stufe-*`, allowing automatic builds and publishing for main release branches.

Conditional job execution improvements:

* Updated the `publish_gate` job condition to run for `pull_request`, `push`, and `workflow_dispatch` events, ensuring publishing checks are performed for all relevant triggers.
* Modified the `publish` job condition to publish when `should_publish` is `true` and the event is any of `pull_request`, `push`, or `workflow_dispatch`, making publishing logic consistent across all triggers.

Robustness in capability statement expansion:

* Added a condition to the `Expand CapabilityStatement` step to only run when `matrix.capability_statement_urls` is not null or empty, preventing unnecessary execution and potential errors.