### PR TITLE
Fix/improve ig pipeline

### DIFF
--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -226,7 +226,7 @@ jobs:
         id: check_changes
         shell: bash
         env:
-          FORCE_BUILD: ${{ github.event.inputs.force_build }}
+          FORCE_BUILD: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'main-stufe-')) || (github.event.inputs.force_build == 'true') }}
           IG_NAME: ${{ matrix.ig_name }}
         run: bash scripts/ig-publisher/check-changes.sh
 

--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -314,14 +314,13 @@ jobs:
 
       - name: Announce published URL
         id: announce_url
-        if: steps.check_changes.outputs.has_changes == 'true' && github.event_name == 'pull_request'
+        if: steps.check_changes.outputs.has_changes == 'true'
         shell: bash
         env:
           IG_NAME: ${{ matrix.ig_name }}
         run: bash scripts/ig-publisher/announce-url.sh
 
       - name: Upload IG URL metadata
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v6
         with:
           name: ig-url-${{ matrix.ig_name }}
@@ -380,12 +379,16 @@ jobs:
 
       # Download all IG URL metadata to create a unified PR comment
       - name: Download IG URL metadata
-        if: github.event_name == 'pull_request'
         uses: actions/download-artifact@v7
         with:
           pattern: ig-url-*
           path: ig-urls
         continue-on-error: true
+
+      - name: Write IG URL summary
+        env:
+          BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: node scripts/ig-publisher/write-summary.js
 
       # Create or update a single PR comment with all published IG URLs
       - name: Update PR comment with all published IGs

--- a/scripts/ig-publisher/write-summary.js
+++ b/scripts/ig-publisher/write-summary.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function collectUrlFiles(igUrlsDir) {
+  const urlFiles = [];
+
+  if (!fs.existsSync(igUrlsDir)) {
+    return urlFiles;
+  }
+
+  const directUrlFile = path.join(igUrlsDir, 'urls.txt');
+  if (fs.existsSync(directUrlFile)) {
+    urlFiles.push(directUrlFile);
+  }
+
+  const artifacts = fs.readdirSync(igUrlsDir);
+  for (const artifact of artifacts) {
+    const urlFile = path.join(igUrlsDir, artifact, 'urls.txt');
+    if (fs.existsSync(urlFile)) {
+      urlFiles.push(urlFile);
+    }
+  }
+
+  return urlFiles;
+}
+
+function readIgUrls(urlFiles) {
+  const igUrls = [];
+
+  for (const urlFile of urlFiles) {
+    const content = fs.readFileSync(urlFile, 'utf8');
+    const lines = content.split('\n');
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      const [igName, url] = line.split('|');
+      if (igName && url) {
+        igUrls.push({ name: igName.trim(), url: url.trim() });
+      }
+    }
+  }
+
+  return igUrls;
+}
+
+function buildSummary({ branch, igUrls }) {
+  const publishedIGs = igUrls.filter((ig) => ig.url !== 'NO_CHANGES');
+  const unchangedIGs = igUrls.filter((ig) => ig.url === 'NO_CHANGES');
+
+  let summary = '## Published Implementation Guides\n';
+
+  if (branch) {
+    summary += `Branch: \`${branch}\`\n\n`;
+  }
+
+  if (publishedIGs.length > 0) {
+    summary += '### Published IGs\n';
+    for (const ig of publishedIGs) {
+      summary += `- **${ig.name}**: ${ig.url}\n`;
+    }
+    summary += '\n';
+  }
+
+  if (unchangedIGs.length > 0) {
+    summary += '### Not yet published\n';
+    for (const ig of unchangedIGs) {
+      summary += `- **${ig.name}**: No changes detected - build skipped\n`;
+    }
+    summary += '\n';
+  }
+
+  return summary;
+}
+
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (!summaryPath) {
+  console.log('GITHUB_STEP_SUMMARY not set - skipping summary output.');
+  process.exit(0);
+}
+
+const igUrlsDir = process.env.IG_URLS_DIR || 'ig-urls';
+const urlFiles = collectUrlFiles(igUrlsDir);
+const igUrls = readIgUrls(urlFiles);
+
+if (igUrls.length === 0) {
+  console.log('No IG URLs found - skipping summary output.');
+  process.exit(0);
+}
+
+const branch =
+  process.env.BRANCH_NAME || process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME;
+
+const summary = buildSummary({ branch, igUrls });
+fs.appendFileSync(summaryPath, summary);
+console.log('Wrote IG URL summary.');


### PR DESCRIPTION
This pull request updates the IG publishing workflow to improve how Implementation Guide (IG) publication summaries are generated and announced. The main changes include refining the build trigger logic, ensuring IG publication URLs are always announced when changes are detected, and introducing a new script to generate a summary of published IGs for easier visibility.

**Workflow improvements and automation:**

* The `FORCE_BUILD` environment variable logic in `.github/workflows/ig-publisher.yml` was updated to trigger builds automatically for pushes to branches starting with `main-stufe-` or when the `force_build` input is `true`, making the build process more robust and less error-prone.
* The announcement step for published IG URLs now runs whenever there are changes, regardless of event type, ensuring that publication URLs are always announced when relevant.

**Artifact and summary handling:**

* The condition for uploading and downloading IG URL metadata artifacts was relaxed, so these steps are no longer limited to pull request events, allowing for more flexible artifact handling. [[1]](diffhunk://#diff-271d9ed984f518b5db3d0e042c436bd2282512e5936141d5355872e67fc824f6L317-L324) [[2]](diffhunk://#diff-271d9ed984f518b5db3d0e042c436bd2282512e5936141d5355872e67fc824f6L383-R392)
* A new script, `scripts/ig-publisher/write-summary.js`, was added to aggregate IG publication results and write a summary (including branch info and publication status) to the GitHub Actions summary, improving visibility for developers and reviewers. [[1]](diffhunk://#diff-4cf55ccadba326ad4a111565a55578aecb787ece91bc29e91a4214dc1f9a412dR1-R98) [[2]](diffhunk://#diff-271d9ed984f518b5db3d0e042c436bd2282512e5936141d5355872e67fc824f6L383-R392)