### PR TITLE
prevent commiting to protected branches

### DIFF
--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -358,7 +358,7 @@ jobs:
   commit:
     needs: [build, publish_gate]
     runs-on: ubuntu-latest
-    if: needs.publish_gate.outputs.should_publish == 'true'
+    if: needs.publish_gate.outputs.should_publish == 'true' && !(github.event_name == 'push' && startsWith(github.ref_name, 'main-stufe-'))
 
     steps:
       # Check out the source branch so commits land in the right place


### PR DESCRIPTION
This pull request makes a targeted update to the GitHub Actions workflow for publishing. The change ensures that the `commit` job only runs when publishing is allowed and the event is not a push to a branch starting with `main-stufe-`.

Workflow condition update:

* Updated the `if` condition for the `commit` job in `.github/workflows/ig-publisher.yml` to prevent commits from running on pushes to branches with names starting with `main-stufe-`.