### PR TITLE
Fix check-changes

### DIFF
--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -39,6 +39,26 @@ on:
         required: false
         type: boolean
         default: false
+      verbose_changes:
+        description: 'Print full change lists in check-changes logs'
+        required: false
+        type: boolean
+        default: false
+      ig_filter:
+        description: 'Limit manual build to a single IG matrix entry'
+        required: false
+        type: choice
+        default: ALL
+        options:
+          - ALL
+          - ISiK-AMTS
+          - ISiK-Formularmodul
+          - ISiK-Basis
+          - ISiK-Vitalparameter
+          - ISiK-Subscriptions
+          - ISiK-Terminplanung
+          - ISiK-Labor
+          - ISiK-Connect
 
 # Ensure only one workflow runs per branch at a time
 # New runs will cancel in-progress runs for the same branch
@@ -102,6 +122,7 @@ jobs:
   # ============================================
   build:
     needs: prepare
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.ig_filter == 'ALL' || matrix.ig_name == github.event.inputs.ig_filter }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gefyra/ig-publisher-with-snapshot-support:latest
@@ -271,6 +292,7 @@ jobs:
         shell: bash
         env:
           FORCE_BUILD: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'main-stufe-')) || (github.event.inputs.force_build == 'true') }}
+          SHOW_ALL_CHANGES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.verbose_changes == 'true' }}
           LAST_SUCCESS_SHA: ${{ steps.resolve_last_success.outputs.last_success_sha }}
           DIFF_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: bash scripts/ig-publisher/check-changes.sh

--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -44,21 +44,6 @@ on:
         required: false
         type: boolean
         default: false
-      ig_filter:
-        description: 'Limit manual build to a single IG matrix entry'
-        required: false
-        type: choice
-        default: ALL
-        options:
-          - ALL
-          - ISiK-AMTS
-          - ISiK-Formularmodul
-          - ISiK-Basis
-          - ISiK-Vitalparameter
-          - ISiK-Subscriptions
-          - ISiK-Terminplanung
-          - ISiK-Labor
-          - ISiK-Connect
 
 # Ensure only one workflow runs per branch at a time
 # New runs will cancel in-progress runs for the same branch
@@ -122,7 +107,6 @@ jobs:
   # ============================================
   build:
     needs: prepare
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.ig_filter == 'ALL' || matrix.ig_name == github.event.inputs.ig_filter }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gefyra/ig-publisher-with-snapshot-support:latest
@@ -228,8 +212,8 @@ jobs:
 
       # Expand capability statements into concrete resources for the IG
       - name: Expand CapabilityStatement
-        uses: Gefyra/capabilityStatement-expander@v0
         if: ${{ toJSON(matrix.capability_statement_urls) != 'null' && toJSON(matrix.capability_statement_urls) != '[]' }}
+        uses: Gefyra/capabilityStatement-expander@v0
         with:
           input_directory: ${{ env.SUSHI_INPUT_DIR }}/fsh-generated
           output_directory: ${{ env.EXPANDED_RESOURCES_DIR }}

--- a/scripts/ig-publisher/README.md
+++ b/scripts/ig-publisher/README.md
@@ -18,6 +18,7 @@ If `LAST_SUCCESS_SHA` is unavailable or invalid, it falls back to the last commi
 **Inputs**
 - `IG_PUBLISHER_DIR`: IG directory under `publisher-guides`
 - `FORCE_BUILD`: `true` to force builds even without detected changes
+- `SHOW_ALL_CHANGES`: `true` to print full change lists instead of truncating to 20 lines per block
 - `LAST_SUCCESS_SHA`: Head SHA from the previous successful workflow run on the same branch
 - `DIFF_HEAD_SHA`: Head commit SHA for diff detection (for PRs: `pull_request.head.sha`)
 

--- a/scripts/ig-publisher/check-changes.sh
+++ b/scripts/ig-publisher/check-changes.sh
@@ -26,6 +26,7 @@ echo ""
 has_changes=false
 diff_range=""
 range_source=""
+show_all_changes="${SHOW_ALL_CHANGES:-false}"
 
 head_sha="${DIFF_HEAD_SHA:-HEAD}"
 if ! git rev-parse --verify "${head_sha}^{commit}" >/dev/null 2>&1; then
@@ -88,25 +89,41 @@ tracked_diff_out=$(echo "${tracked_diff_out}" | sed '/^[[:space:]]*$/d')
 tracked_history_out=$(echo "${tracked_history_out}" | sed '/^[[:space:]]*$/d' | awk '!seen[$0]++')
 workspace_status_out=$(echo "${workspace_status_out}" | sed '/^[[:space:]]*$/d')
 
+print_changes_block() {
+  local heading="$1"
+  local content="$2"
+  local max_lines=20
+
+  if [ -z "${content}" ]; then
+    return
+  fi
+
+  local total_lines
+  total_lines=$(printf '%s\n' "${content}" | wc -l | awk '{print $1}')
+
+  echo "${heading}"
+  if [ "${show_all_changes}" = "true" ] || [ "${total_lines}" -le "${max_lines}" ]; then
+    printf '%s\n' "${content}"
+  else
+    sed -n "1,${max_lines}p" <<< "${content}"
+    echo "... (${total_lines} total lines, showing first ${max_lines}; set SHOW_ALL_CHANGES=true for full output)"
+  fi
+  echo ""
+}
+
 if [ -n "${tracked_diff_out}" ]; then
   has_changes=true
-  echo "Detected net tracked changes (git diff):"
-  echo "${tracked_diff_out}" | head -20
-  echo ""
+  print_changes_block "Detected net tracked changes (git diff):" "${tracked_diff_out}"
 fi
 
 if [ -n "${tracked_history_out}" ]; then
   has_changes=true
-  echo "Detected tracked files touched in commits (git log):"
-  echo "${tracked_history_out}" | head -20
-  echo ""
+  print_changes_block "Detected tracked files touched in commits (git log):" "${tracked_history_out}"
 fi
 
 if [ -n "${workspace_status_out}" ]; then
   has_changes=true
-  echo "Detected workspace changes (git status, including untracked):"
-  echo "${workspace_status_out}" | head -20
-  echo ""
+  print_changes_block "Detected workspace changes (git status, including untracked):" "${workspace_status_out}"
 fi
 
 if [ "$has_changes" = true ]; then


### PR DESCRIPTION
This pull request adds a new option to print the full list of detected changes in the IG Publisher workflow logs, instead of truncating them to 20 lines per block. This is controlled by a new `verbose_changes` input in the workflow, which sets the `SHOW_ALL_CHANGES` environment variable. The summary and printing logic in `check-changes.sh` has been refactored to support this feature.

**Workflow and environment variable enhancements:**

* Added a `verbose_changes` boolean input to `.github/workflows/ig-publisher.yml` to allow users to request full change lists in logs.
* Set the `SHOW_ALL_CHANGES` environment variable in the workflow based on the `verbose_changes` input, and documented this new variable in `scripts/ig-publisher/README.md`. [[1]](diffhunk://#diff-271d9ed984f518b5db3d0e042c436bd2282512e5936141d5355872e67fc824f6R279) [[2]](diffhunk://#diff-32537fbb32c98c6a1693544d7f81993d4c6088985e738ab292fd7bfbb1c18270R21)

**Script improvements:**

* Updated `scripts/ig-publisher/check-changes.sh` to read the `SHOW_ALL_CHANGES` variable and introduced a `print_changes_block` helper function to handle printing either a truncated or full list of changes per block. [[1]](diffhunk://#diff-cbde05a797b47c05cb613e9ac7d5e35bf30eaec8cb65da5af45ca2800a086a91R29) [[2]](diffhunk://#diff-cbde05a797b47c05cb613e9ac7d5e35bf30eaec8cb65da5af45ca2800a086a91R92-R126)