### PR TITLE
add bundle in CpS

### DIFF
--- a/Resources/input/fsh/Dokumentenaustausch/Rollen/ISiKCapabilityStatementDokumentenverwaltungRolle.fsh
+++ b/Resources/input/fsh/Dokumentenaustausch/Rollen/ISiKCapabilityStatementDokumentenverwaltungRolle.fsh
@@ -30,6 +30,7 @@ Diese Rolle beschreibt verpflichtende Interaktionen zur Erstellung, dem Abruf un
     * code = #search-type
   * insert CommonSearchParameters
 
+
   * searchParam[+]
     * insert Expectation (#SHALL)
     * name = "status"
@@ -130,3 +131,8 @@ Diese Rolle beschreibt verpflichtende Interaktionen zur Erstellung, dem Abruf un
     Falls ein solcher Accept-Header durch einen Client verwendet wird, MUSS  bestätigungsrelevante System (Server)
     das Binary in seiner nativen Form (definiert durch Binary.contentType) zurückgeben."
 
+* rest.resource[+]
+  * insert Expectation (#SHALL)
+  * type = #Bundle
+  * supportedProfile = "https://gematik.de/fhir/isik/StructureDefinition/ISiKDokumentenSuchergebnisse"
+    * insert Expectation (#SHALL)


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

[**Contributor PR**](?expand=1&template=PR_Template_Contributor.md)

[Version Upgrade **(for Admins)**](?expand=1&template=PR_Template_VersionUpgrade.md)

[Version Upgrade **(for Admins)** Stufe 5 following ](?expand=1&template=PR_Template_VersionUpgrade.md)


<!--- If you have no idea, time, what so ever, you can also continue here without using a pull request template-->
<!--- Please keep in mind that if you use this short cut, your PR is lees likely to be merged, because of missing information.-->
## Pull Request Short Cut
<!--- Describe your changes briefly. If you need some space to describe, please use the contributor template as mentioned at the top-->
Problem: es fehlt in Stufe 6 das Profil zum Bundle im CpS und im IG - vgl. https://simplifier.net/guide/isik-dokumentenaustausch-stufe-5/Einfuehrung/Artefakte/Datenobjekte_Bundle

Um es in den IG Publisher hinzuzufügen, muss der Ressourcentypo in der entsprechenden CpS Rolle geführt werden.
Vgl. https://github.com/gematik/spec-ISiK-Basismodul/pull/977#issuecomment-3943796164 

