### PR TITLE
added missing comments in ISiKPersonImGesundheitsberuf.name

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKAngehoeriger.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKAngehoeriger.json
@@ -92,7 +92,6 @@
         },
         "short": "Offizieller Name der angehörigen Person",
         "comment": "Aufgrund der primären Nutzung von Angehörigen-Informationen im ISiK-Kontext als Brief- und Rechnungsempfänger, \n  ist die Angabe des offiziellen Namens relevant.\n  Wenn kein Name vorliegt, MUSS die [data-absent-reason-Extension](https://www.hl7.org/fhir/R4/extension-data-absent-reason.html) eingesetzt werden.   \n  **Weitere Hinweise:** siehe [Deutsche Basisprofile](https://simplifier.net/guide/leitfaden-de-basis-r4/ig-markdown-Ressourcen-Patient?version=current#ig-markdown-Ressourcen-Patient-Name)",
-        "min": 1,
         "mustSupport": true
       },
       {
@@ -101,7 +100,7 @@
         "sliceName": "Name",
         "short": "Slice für den offiziellen Namen der angehörigen Person",
         "comment": "Basierend auf dem Pattern .use = official wird dieser Slice gewählt.\n  **Begründung MS:** Siehe untergeordnete Elemente",
-        "min": 1,
+        "min": 0,
         "max": "1",
         "type": [
           {
@@ -127,13 +126,13 @@
         "id": "RelatedPerson.name:Name.family",
         "path": "RelatedPerson.name.family",
         "short": "Nachname",
-        "comment": "Vollständiger Nachname bzw. Familienname der Person, einschließlich Vor- und Zusätze.  \n      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind.",
+        "comment": "Vollständiger Nachname bzw. Familienname der Person, einschließlich Vor- und Zusätze.",
         "mustSupport": true
       },
       {
         "id": "RelatedPerson.name:Name.given",
         "path": "RelatedPerson.name.given",
-        "comment": "Kann mehrfach verwendet werden, um den Rufnamen sowie weitere Vornamen, Mittelnamen oder Mittel-Initialen abzubilden.\n      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind.",
+        "comment": "Kann mehrfach verwendet werden, um den Rufnamen sowie weitere Vornamen, Mittelnamen oder Mittel-Initialen abzubilden.",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKPersonImGesundheitsberuf.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKPersonImGesundheitsberuf.json
@@ -210,6 +210,8 @@
       {
         "id": "Practitioner.name:Name.use",
         "path": "Practitioner.name.use",
+        "short": "Verwendungszweck",
+        "comment": "Hier ist stets der Wert `official` anzugeben.\n      **Begründung Pflichtfeld:** Dient als Unterscheidungs- und Auswahlkriterium",
         "min": 1,
         "fixedCode": "official",
         "mustSupport": true
@@ -217,18 +219,23 @@
       {
         "id": "Practitioner.name:Name.family",
         "path": "Practitioner.name.family",
+        "short": "Nachname",
+        "comment": "Vollständiger Nachname bzw. Familienname der Person, einschließlich Vor- und Zusätze.  \n      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind.",
         "min": 1,
         "mustSupport": true
       },
       {
         "id": "Practitioner.name:Name.given",
         "path": "Practitioner.name.given",
+        "comment": "Kann mehrfach verwendet werden, um den Rufnamen sowie weitere Vornamen, Mittelnamen oder Mittel-Initialen abzubilden.\n      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind.",
         "min": 1,
         "mustSupport": true
       },
       {
         "id": "Practitioner.name:Name.prefix",
         "path": "Practitioner.name.prefix",
+        "short": "Präfix",
+        "comment": "Präfix, z.B. akademischer Titel od. militärischer Rang",
         "mustSupport": true
       },
       {

--- a/Resources/input/fsh/Basis/ISiKAngehoeriger.fsh
+++ b/Resources/input/fsh/Basis/ISiKAngehoeriger.fsh
@@ -62,7 +62,7 @@ Hinweise zu Inkompatibilitäten können über die [Portalseite](https://service.
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
 * name contains
-    Name 1..1 MS 
+    Name ..1 MS 
 * name[Name] only HumannameDeBasis
   * ^patternHumanName.use = #official
   * ^short = "Slice für den offiziellen Namen der angehörigen Person"
@@ -73,14 +73,12 @@ Hinweise zu Inkompatibilitäten können über die [Portalseite](https://service.
     * ^comment = "Verwendungszweck des Namens. Der präferierte Namen für die Brief- und Rechnungszustellung SOLLTE als `official`
     gekennzeichnet werden und mindestens über einen Vor- und Nachnamen verfügen.    
     **Begründung MS:** Dient als Unterscheidungs- und Auswahlkriterium"  
-  * family  MS
+  * family MS
     * ^short = "Nachname"
-    * ^comment = "Vollständiger Nachname bzw. Familienname der Person, einschließlich Vor- und Zusätze.  
-      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind."   
-  * given  MS
+    * ^comment = "Vollständiger Nachname bzw. Familienname der Person, einschließlich Vor- und Zusätze."
+  * given MS
     * ^short = "Vorname"
-    * ^comment = "Kann mehrfach verwendet werden, um den Rufnamen sowie weitere Vornamen, Mittelnamen oder Mittel-Initialen abzubilden.
-      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind."   
+    * ^comment = "Kann mehrfach verwendet werden, um den Rufnamen sowie weitere Vornamen, Mittelnamen oder Mittel-Initialen abzubilden."
   * prefix MS
     * ^short = "Präfix"
     * ^comment = "Präfix, z.B. akademischer Titel od. militärischer Rang"   

--- a/Resources/input/fsh/Basis/ISiKPersonImGesundheitsberuf.fsh
+++ b/Resources/input/fsh/Basis/ISiKPersonImGesundheitsberuf.fsh
@@ -60,10 +60,21 @@ Während die Deutschen Basisprofile hier die Abkürzung LANR verwenden, ist im K
   * ^comment = "Der Name des Arztes MUSS in konkreten Anwendungen angezeigt werden können. Es MUSS nach dem Namen des Arztes gesucht werden können."
   * ^patternHumanName.use = #official
   * use 1.. MS
+    * ^short = "Verwendungszweck"
+    * ^comment = "Hier ist stets der Wert `official` anzugeben.
+      **Begründung Pflichtfeld:** Dient als Unterscheidungs- und Auswahlkriterium"  
   * use = #official (exactly)
   * family 1.. MS
+    * ^short = "Nachname"
+    * ^comment = "Vollständiger Nachname bzw. Familienname der Person, einschließlich Vor- und Zusätze.  
+      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind."   
   * given 1.. MS
+    * ^short = "Vorname"
+    * ^comment = "Kann mehrfach verwendet werden, um den Rufnamen sowie weitere Vornamen, Mittelnamen oder Mittel-Initialen abzubilden.
+      **Begründung Pflichtfeld:** Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind."   
   * prefix MS
+    * ^short = "Präfix"
+    * ^comment = "Präfix, z.B. akademischer Titel od. militärischer Rang"   
 * name[Geburtsname] only HumannameDeBasis
   * ^patternHumanName.use = #maiden
   * use 1.. MS

--- a/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
@@ -23,6 +23,7 @@ Die Tags werden folgendermaßen verwendet:
 * `fix` Schwächung der Verpflichtung zur Umsetzung des Suchparameters '_tag' von `SHALL` zu `MAY` https://github.com/gematik/spec-ISiK-Basismodul/pull/1034
 * `fix` ValueSet-Binding in Procedure.code[Ops] auf OpsVS entfernt, da dieses ValueSet in ValueSet.compose.include.version ein "*" verwendet. Dieses Feature wird von gängigen Terminologieservern nicht unterstützt und führt zu Validierungsfehlern. Durch die weiterhin bestehende Verwendung des OpsCoding-Profils ergibt sich jedoch keine inhaltliche Änderung.
 * `documentation` Beschreibung des Profils `ISiKVersicherungsverhaeltnisSelbstzahler` wurde korrigiert https://github.com/gematik/spec-ISiK-Basismodul/pull/1031
+* `improve` Lockerung der Name-Kardinalität von 1..1 auf ..1 im Profil ISiKAngehoeriger; Ergänzung fehlender Kommentare im Profil ISiKPersonImGesundheitsberuf https://github.com/gematik/spec-ISiK-Basismodul/pull/1059
 
 ## Version 5.1.1
 


### PR DESCRIPTION
# PR Changelog: PTDATA-2141 Name Cardinality Fix

**Branch:** `stufe-5/basis/fix/PTDATA-2141-name-cardinality`  
**Base Branch:** `main-stufe-5`  
**Files Changed:** 2

## 📝 Zusammenfassung

Dieser Pull Request behebt die Name-Kardinalität im ISiKAngehoeriger-Profil und ergänzt fehlende Kommentare im ISiKPersonImGesundheitsberuf-Profil.

## 🔧 Änderungen im Detail

### ISiKAngehoeriger.fsh

#### Name-Slice Kardinalität gelockert
- **Geändert:** Name-Slice Kardinalität von `1..1 MS` auf `..1 MS`
- **Auswirkung:** Der Name ist nun optional statt verpflichtend
- **Begründung:** Mehr Flexibilität in Szenarien, wo kein Name vorliegt (mit data-absent-reason-Extension)

#### Kommentare aktualisiert
- **Entfernt:** "Begründung Pflichtfeld" aus `family` und `given` Elementen
- **Grund:** Da Name nun optional ist, sind die einzelnen Elemente innerhalb des Slices nicht mehr global verpflichtend
- Kleine Formatierungsbereinigungen (Leerzeichen)

### ISiKPersonImGesundheitsberuf.fsh

#### Dokumentation erweitert
- **Hinzugefügt:** Fehlende `^short` und `^comment` Annotationen für:
  - `use`: Verwendungszweck mit Begründung für Pflichtfeld
  - `family`: Nachname mit Beschreibung und Begründung
  - `given`: Vorname mit Beschreibung und Begründung  
  - `prefix`: Präfix mit Beschreibung

- **Zweck:** Vollständige und konsistente Dokumentation aller Name-Elemente
- **Begründung Pflichtfeld:** "Ein offizieller Name ist nur zulässig, wenn der Nachname und mindestens ein Vorname angegeben sind."

## 🎯 Auswirkungen

- **ISiKAngehoeriger:** Name-Angabe ist nun optional (kann über data-absent-reason-Extension ersetzt werden)
- **ISiKPersonImGesundheitsberuf:** Verbesserte Dokumentation für Implementierer
- Konsistentere FSH-Profilstruktur über beide Profile hinweg
