### PR TITLE
PTDATA-1909: update search parameters in CapabilityStatement

### DIFF
--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
@@ -268,10 +268,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -280,10 +280,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [

--- a/Resources/input/fsh/Basis/Rollen/ISiKCapabilityStatementGesundheitsstatusRolle.fsh
+++ b/Resources/input/fsh/Basis/Rollen/ISiKCapabilityStatementGesundheitsstatusRolle.fsh
@@ -100,22 +100,22 @@ Diese Rolle beschreibt verpflichtende Interaktionen zum Abruf und der Verarbeitu
         Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#date).  "
     * searchParam[+]
       * insert Expectation(#SHALL)
-      * name = "combo-code"
-      * definition = "http://hl7.org/fhir/SearchParameter/Observation-combo-code"
-      * type = #token
-      * documentation = 
-        "**Beispiel:**    
-        `GET [base]/Observation?combo-code=85354-9`    
-        **Anwendungshinweis:**   
-        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
-    * searchParam[+]
-      * insert Expectation(#SHALL)
-      * name = "combo-code-value-quantity"
-      * definition = "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity"
+      * name = "code-value-concept"
+      * definition = "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept"
       * type = #composite
       * documentation = 
         "**Beispiel:**    
-        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    
+        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    
+        **Anwendungshinweis:**   
+        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+    * searchParam[+]
+      * insert Expectation(#SHALL)
+      * name = "code-value-date"
+      * definition = "http://hl7.org/fhir/SearchParameter/Observation-code-value-date"
+      * type = #composite
+      * documentation = 
+        "**Beispiel:**    
+        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    
         **Anwendungshinweis:**   
         Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
     * searchParam[+]

--- a/publisher-guides/AMTS/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/AMTS/input/pagecontent/ReleaseNotes.md
@@ -7,3 +7,4 @@ Datum: tbd
 * Initiales release
 * `fix` Schwächung der Verpflichtung zur Umsetzung des Suchparameters '_tag' von `SHALL` zu `MAY` - amalog zu TC 5.1.2 https://github.com/gematik/spec-ISiK-Basismodul/pull/1040
 * `improve` Verpflichtende Einführung des Suchparameters `_lastUpdated`  https://github.com/gematik/spec-ISiK-Basismodul/pull/1053
+* `fix` Ersetzen der Suchparameter `combo-code` und `combo-code-value-quantity` durch die neueren Suchparameter `code-value-concept` und `code-value-date` https://github.com/gematik/spec-ISiK-Basismodul/pull/1066

--- a/publisher-guides/AMTS/input/resources/CapabilityStatement-ISiKCapabilityStatementAMTSAkteur-expanded.json
+++ b/publisher-guides/AMTS/input/resources/CapabilityStatement-ISiKCapabilityStatementAMTSAkteur-expanded.json
@@ -724,6 +724,30 @@
               "name": "component-code",
               "definition": "http://hl7.org/fhir/SearchParameter/Observation-component-code",
               "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             }
           ],
           "_supportedProfile": [

--- a/publisher-guides/AMTS/input/resources/CapabilityStatement-ISiKCapabilityStatementBasisServerAkteur-expanded.json
+++ b/publisher-guides/AMTS/input/resources/CapabilityStatement-ISiKCapabilityStatementBasisServerAkteur-expanded.json
@@ -1324,10 +1324,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -1336,10 +1336,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [

--- a/publisher-guides/AMTS/input/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
+++ b/publisher-guides/AMTS/input/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
@@ -268,10 +268,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -280,10 +280,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [

--- a/publisher-guides/Basis/input/resources/CapabilityStatement-ISiKCapabilityStatementBasisServerAkteur-expanded.json
+++ b/publisher-guides/Basis/input/resources/CapabilityStatement-ISiKCapabilityStatementBasisServerAkteur-expanded.json
@@ -1324,10 +1324,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -1336,10 +1336,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [

--- a/publisher-guides/Basis/input/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
+++ b/publisher-guides/Basis/input/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
@@ -268,10 +268,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -280,10 +280,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [

--- a/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementBasisServerAkteur-expanded.json
+++ b/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementBasisServerAkteur-expanded.json
@@ -1324,10 +1324,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -1336,10 +1336,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [

--- a/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
+++ b/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
@@ -268,10 +268,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code",
-              "type": "token",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code=85354-9`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#token).  "
+              "name": "code-value-concept",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-concept",
+              "type": "composite",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-concept=http://loinc.org|72166-2$http://loinc.org|LA15920-4`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [
@@ -280,10 +280,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "combo-code-value-quantity",
-              "definition": "http://hl7.org/fhir/SearchParameter/Observation-combo-code-value-quantity",
+              "name": "code-value-date",
+              "definition": "http://hl7.org/fhir/SearchParameter/Observation-code-value-date",
               "type": "composite",
-              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?combo-code-value-quantity=http://loinc.org|8480-6$120|http://unitsofmeasure.org|mm[Hg]`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
+              "documentation": "**Beispiel:**    \n        `GET [base]/Observation?code-value-date=http://loinc.org|11779-6$2024-08-01`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#composite).  "
             },
             {
               "extension": [


### PR DESCRIPTION
[PTDATA-1909](https://service.gematik.de/browse/PTDATA-1909)

This pull request updates the search parameters for the Gesundheitsstatus role in both the FSH source and generated JSON CapabilityStatement. The main focus is to replace older token-based and quantity composite search parameters with newer composite search parameters that better align with current FHIR standards.

**Search parameter updates:**

* Replaced the `combo-code` search parameter (token type) with the new `code-value-concept` composite search parameter, including updated example and documentation references. [[1]](diffhunk://#diff-5a71f67048995246486cc69f97e8bce53a9a17c9ab4551191c4e5e94d729a214L271-R274) [[2]](diffhunk://#diff-d868e913aff51d35113e5d65bfa1dbb7750084b7e595bcde85e2b07aad2b15f1L103-R118)
* Replaced the `combo-code-value-quantity` search parameter with the new `code-value-date` composite search parameter, including updated example and documentation references. [[1]](diffhunk://#diff-5a71f67048995246486cc69f97e8bce53a9a17c9ab4551191c4e5e94d729a214L283-R286) [[2]](diffhunk://#diff-d868e913aff51d35113e5d65bfa1dbb7750084b7e595bcde85e2b07aad2b15f1L103-R118)