### PR TITLE
feat: add Must-Support annotations for doseQuantity and doseRange in medicationinformation to remove validation errors

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -738,6 +738,15 @@
         "mustSupport": true
       },
       {
+        "id": "Encounter.location.physicalType",
+        "path": "Encounter.location.physicalType",
+        "comment": "Die Kodierung in diesem Slice entstammt folgendem Valueset - gelistet unter .location.(All slices.)physicalType: https://gematik.de/fhir/isik/ValueSet/ISiKLocationPhysicalType",
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
+        }
+      },
+      {
         "id": "Encounter.location:Zimmer",
         "path": "Encounter.location",
         "sliceName": "Zimmer",
@@ -893,7 +902,6 @@
         "id": "Encounter.location:Bettenstellplatz.physicalType",
         "path": "Encounter.location.physicalType",
         "short": "Art des Aufenthaltsortes (hier: Bettenstellplatz)",
-        "comment": "Die Kodierung in diesem Slice entstammt folgendem Valueset - gelistet unter .location.(All slices.)physicalType: https://gematik.de/fhir/isik/ValueSet/ISiKLocationPhysicalType",
         "min": 1,
         "patternCodeableConcept": {
           "coding": [

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsInformation.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsInformation.json
@@ -879,6 +879,49 @@
         "mustSupport": true
       },
       {
+        "id": "MedicationStatement.dosage.doseAndRate.dose[x]:doseQuantity",
+        "path": "MedicationStatement.dosage.doseAndRate.dose[x]",
+        "sliceName": "doseQuantity",
+        "short": "Dosis",
+        "comment": "Das Must-Support-Flag auf doseQuantity bedeutet, dass produzierende Systeme zur Kodierung der Dosisangaben nach eigenem Ermessen entweder den Datentyp Quantity oder Ratio verwenden können. Beim Empfang und Verarbeitung der eingehenden Daten müssen dagegen beide Datentypen interpretiert werden können.",
+        "type": [
+          {
+            "code": "Quantity",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "MedicationStatement.dosage.doseAndRate.dose[x]:doseQuantity.value",
+        "path": "MedicationStatement.dosage.doseAndRate.dose[x].value",
+        "short": "Dosiswert",
+        "comment": "**Begründung MS:** Der Dosiswert ist notwendig, um die Dosisangabe korrekt interpretieren zu können.",
+        "mustSupport": true
+      },
+      {
+        "id": "MedicationStatement.dosage.doseAndRate.dose[x]:doseQuantity.unit",
+        "path": "MedicationStatement.dosage.doseAndRate.dose[x].unit",
+        "short": "Menschenlesbare Dosis-Einheit",
+        "comment": "**Begründung MS:** Die menschenlesbare Dosis-Einheit ist notwendig, um die Dosisangabe korrekt interpretieren zu können.",
+        "mustSupport": true
+      },
+      {
+        "id": "MedicationStatement.dosage.doseAndRate.dose[x]:doseQuantity.system",
+        "path": "MedicationStatement.dosage.doseAndRate.dose[x].system",
+        "short": "CodeSystem der Dosisangabe",
+        "comment": "**Begründung MS:** Das CodeSystem der Dosisangabe ist notwendig, um die Dosisangabe korrekt interpretieren zu können.",
+        "mustSupport": true
+      },
+      {
+        "id": "MedicationStatement.dosage.doseAndRate.dose[x]:doseQuantity.code",
+        "path": "MedicationStatement.dosage.doseAndRate.dose[x].code",
+        "short": "Code der Dosisangabe",
+        "comment": "**Begründung MS:** Der Code der Dosisangabe ist notwendig, um die Dosisangabe korrekt interpretieren zu können.",
+        "mustSupport": true
+      },
+      {
         "id": "MedicationStatement.dosage.doseAndRate.dose[x]:doseRange",
         "path": "MedicationStatement.dosage.doseAndRate.dose[x]",
         "sliceName": "doseRange",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKStandort.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKStandort.json
@@ -124,8 +124,8 @@
         "min": 1,
         "mustSupport": true,
         "binding": {
-          "strength": "required",
-          "valueSet": "http://terminology.hl7.org/ValueSet/location-physical-type"
+          "strength": "extensible",
+          "valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
         }
       },
       {

--- a/Resources/input/fsh/Medikation/ISiKMedikationsInformation.fsh
+++ b/Resources/input/fsh/Medikation/ISiKMedikationsInformation.fsh
@@ -265,6 +265,21 @@ Für die Abbildung der Pausierung einer Medikation wird empfohlen, **mehrere `Me
       * ^patternCoding.system = $cs-sct
     * text MS
   * doseAndRate 
+    * doseQuantity MS
+      * ^short = "Dosis"
+      * ^comment = "Das Must-Support-Flag auf doseQuantity bedeutet, dass produzierende Systeme zur Kodierung der Dosisangaben nach eigenem Ermessen entweder den Datentyp Quantity oder Ratio verwenden können. Beim Empfang und Verarbeitung der eingehenden Daten müssen dagegen beide Datentypen interpretiert werden können."
+      * value MS
+        * ^short = "Dosiswert"
+        * ^comment = "**Begründung MS:** Der Dosiswert ist notwendig, um die Dosisangabe korrekt interpretieren zu können."
+      * unit MS
+        * ^short = "Menschenlesbare Dosis-Einheit"
+        * ^comment = "**Begründung MS:** Die menschenlesbare Dosis-Einheit ist notwendig, um die Dosisangabe korrekt interpretieren zu können."
+      * system MS
+        * ^short = "CodeSystem der Dosisangabe"
+        * ^comment = "**Begründung MS:** Das CodeSystem der Dosisangabe ist notwendig, um die Dosisangabe korrekt interpretieren zu können."
+      * code MS
+        * ^short = "Code der Dosisangabe"
+        * ^comment = "**Begründung MS:** Der Code der Dosisangabe ist notwendig, um die Dosisangabe korrekt interpretieren zu können."
     * doseRange MS
       * ^short = "Dosisbereich"
       * low MS


### PR DESCRIPTION
This pull request introduces several important updates to the FHIR StructureDefinitions and related FSH files, focusing on improving the representation of medication dosage information and refining the handling of location physical types. The most significant changes are the addition of detailed Must-Support flags and comments for medication dose quantities, as well as updates to value set bindings for location physical types to ensure better extensibility and alignment with FHIR standards.

**Medication Dosage Representation Improvements:**

* Added a new `doseQuantity` slice to `MedicationStatement.dosage.doseAndRate.dose[x]` with Must-Support flags and detailed comments for its value, unit, system, and code subfields, ensuring that both producing and consuming systems can handle dosage information flexibly and accurately. [[1]](diffhunk://#diff-52942d73c2e9f91d9ea20c82d7eefbe9a6adf139d1e40f2e4ebf25401ec28912R881-R923) [[2]](diffhunk://#diff-b40236983f0b7dc0a3cd7b7e52237aee8e959e939844c607ccbb7220e196ac5cR268-R282)