### PR TITLE
PTDATA-1859 QuestionnaireResponse in $book

### DIFF
--- a/Resources/input/fsh/Formulare/FormularDaten.fsh
+++ b/Resources/input/fsh/Formulare/FormularDaten.fsh
@@ -17,6 +17,10 @@ Die verwendbaren Extensions sind nicht mit profiliert, sondern im IG unter Spezi
   * ^comment = "**Begründung MS:**
   In dieser Extension wird die Zweckbestimmung angegeben, welche die FormularDefinition, auf der diese FormularDaten basieren, für die Verwendung innerhalb eines Medizinproduktes identifiziert hat. Sobald diese Extension vorhanden ist, sollten die Konsequenzen für die Anzeige und Verarbeitung der FormularDaten geprüft werden. Ein Formularrenderer, der sich nicht mit dem Thema MDR und Medizinprodukte auseinandergesetzt hat, sollte hier auf das im FHIR-Standard festgelegte Verhalten bei [modifierExtension](http://hl7.org/fhir/extensibility.html#modifierExtension) zurückgreifen."  
 * modifierExtension[MpFormular].valueString MS
+* text MS
+  * ^short = "Menschlich lesbare Zusammenfassung der FormularDaten"
+  * ^comment = "**Begründung MS:**
+  Wird ein Formular nicht im Kontext der `Datenübermittlung aus Subsystemen` übertragen, wo ein Narrativ im Kontext der Composition gefordert wird, muss an dieser Stelle eine menschenlesbare Zusammenfassung der FormularDaten bereitgestellt werden, damit die Informationen auch ohne Zugriff auf die zugrunde liegende FormularDefinition und die strukturierte Darstellung der Formulardaten interpretiert werden können."
 * identifier MS
   * ^short = "eindeutiger Identifier der FormularDaten"
   * ^comment = "**Begründung MS:**

--- a/Resources/input/fsh/Terminplanung/ISiKBookOperation.fsh
+++ b/Resources/input/fsh/Terminplanung/ISiKBookOperation.fsh
@@ -51,6 +51,12 @@ Usage: #example
   * documentation	= "Dieser Parameter KANN durch einen Client und MUSS durch ein Termin-Repository unterstützt werden. Wird der Parameter unterstützt, dann gelten folgende Festlegungen: Eine RelatedPerson-Ressource, die eine Person identifiziert, die den Termin im Namen des Patienten bucht. Die Ressource KANN vom ISiKRelatedPerson-Profil abweichen, falls für die Terminbuchung irrelevante Pflichtangaben aus dem Profil nicht bekannt sind. Invalide Ressourcen MÜSSEN vom Termin-Repository abgelehnt werden (siehe Form der Ablehnung unten). Dieser Parameter dient der Übermittlung der RelatedPerson-Informationen, falls diese dem Termin-Repository noch nicht bekannt sind. Das Termin-Repository SOLL im bestätigten Termin eine Referenz auf eine RelatedPerson zurückgeben, sofern keine RelatedPerson unter Appointment.participant im 'appt-resource'-Parameter referenziert ist."
   * type = #Patient
 * parameter[+]
+  * name = #patientSubmittedInformation
+  * use = #in
+  * min = 0
+  * max = "1"
+  * documentation = "Dieser Parameter KANN durch einen Client und MUSS durch ein Termin-Repository unterstützt werden. Wird der Parameter unterstützt, dann gelten folgende Festlegungen: Eine QuestionnaireResponse-Ressource KANN übergeben werden, um patientenseitig erhobene Angaben im Rahmen der Terminbuchung zu übermitteln. Dies ermöglicht eine dynamische Ausgestaltung der $book-Operation für unterschiedliche Anwendungsfälle, ohne dass Änderungen an der Spezifikation erforderlich sind. Die Inhalte KÖNNEN insbesondere anamnestische Informationen, Angaben zum Bedarf an Mobilitätshilfen oder Übersetzungsleistungen sowie Bestätigungen zur Kenntnisnahme von Informationen oder zur Kostenübernahme umfassen. Das Portalsystem MUSS im ersten Ausbauschritt mindestens die Fragen und Antworten innerhalb der QuestionnaireResponse übermitteln; die zugrundeliegende Questionnaire-Definition MUSS nicht mitgeliefert oder durch das empfangende System aufgelöst werden. Das Element QuestionnaireResponse.questionnaire SOLL jedoch befüllt sein, damit unterschiedlich strukturierte QuestionnaireResponses unterschieden und perspektivisch automatisiert verarbeitet werden können. Das Element QuestionnaireResponse.text MUSS befüllt sein, damit die übermittelten Informationen durch das empfangende System unmittelbar gerendert werden können. Invalide Ressourcen MÜSSEN vom Termin-Repository abgelehnt werden (zur Form der Ablehnung s.u.)."
+* parameter[+]
   * name = #return
   * use = #out
   * min = 0

--- a/Resources/input/fsh/Terminplanung/ISiKBookOperation.fsh
+++ b/Resources/input/fsh/Terminplanung/ISiKBookOperation.fsh
@@ -56,6 +56,7 @@ Usage: #example
   * min = 0
   * max = "1"
   * documentation = "Dieser Parameter KANN durch einen Client und MUSS durch ein Termin-Repository unterstützt werden. Wird der Parameter unterstützt, dann gelten folgende Festlegungen: Eine QuestionnaireResponse-Ressource KANN übergeben werden, um patientenseitig erhobene Angaben im Rahmen der Terminbuchung zu übermitteln. Dies ermöglicht eine dynamische Ausgestaltung der $book-Operation für unterschiedliche Anwendungsfälle, ohne dass Änderungen an der Spezifikation erforderlich sind. Die Inhalte KÖNNEN insbesondere anamnestische Informationen, Angaben zum Bedarf an Mobilitätshilfen oder Übersetzungsleistungen sowie Bestätigungen zur Kenntnisnahme von Informationen oder zur Kostenübernahme umfassen. Das Portalsystem MUSS im ersten Ausbauschritt mindestens die Fragen und Antworten innerhalb der QuestionnaireResponse übermitteln; die zugrundeliegende Questionnaire-Definition MUSS nicht mitgeliefert oder durch das empfangende System aufgelöst werden. Das Element QuestionnaireResponse.questionnaire SOLL jedoch befüllt sein, damit unterschiedlich strukturierte QuestionnaireResponses unterschieden und perspektivisch automatisiert verarbeitet werden können. Das Element QuestionnaireResponse.text MUSS befüllt sein, damit die übermittelten Informationen durch das empfangende System unmittelbar gerendert werden können. Invalide Ressourcen MÜSSEN vom Termin-Repository abgelehnt werden (zur Form der Ablehnung s.u.)."
+  * type = #QuestionnaireResponse
 * parameter[+]
   * name = #return
   * use = #out

--- a/guides/Terminplanung-5/Einfuehrung/Festlegungen/Operations.page.md
+++ b/guides/Terminplanung-5/Einfuehrung/Festlegungen/Operations.page.md
@@ -260,6 +260,14 @@ Mindestens einer der nachfolgenden Wege MUSS unterstützt werden, um eine Patien
 - Übergabe innerhalb der `$book`-Operation:
   Das Termin-Repository unterstützt die Übergabe einer Patient-Instanz mittels des dafür vorgesehenen Parameters innerhalb der `$book`-Operation.
 
+### Übermittlung zusätzlicher Patientenangaben
+
+Zusätzlich KANN innerhalb der `$book`-Operation über den Parameter `patientSubmittedInformation` eine `QuestionnaireResponse`-Ressource übermittelt werden, um patientenseitig erhobene Angaben im Rahmen der Terminbuchung zu übertragen. Dies ermöglicht es insbesondere Portalsystemen, abhängig vom Anwendungsfall oder von der Terminart unterschiedliche Fragen zu stellen, ohne dass hierfür Änderungen an der Spezifikation erforderlich sind.
+
+Im ersten Ausbauschritt genügt es, wenn die `QuestionnaireResponse` die Fragen und Antworten selbst enthält. Eine Auflösung oder Mitlieferung der zugrundeliegenden `Questionnaire`-Definition ist hierfür nicht erforderlich. Das Element `QuestionnaireResponse.questionnaire` SOLL jedoch befüllt sein, damit unterschiedlich strukturierte Antworten unterschieden und perspektivisch automatisiert verarbeitet werden können. Das Element `QuestionnaireResponse.text` MUSS befüllt sein, damit die Inhalte durch das empfangende System unmittelbar dargestellt werden können.
+
+Die Vorgaben aus dem [ISiK-Formularmodul](https://gemspec.gematik.de/ig/fhir/isik/formularmodul/6.0.0-rc/index.html) sind für die `QuestionnaireResponse`-Ressource entsprechend anzuwenden, insbesondere hinsichtlich der Kodierung von Fragen und Antworten.
+
 ### Asynchrone Ausführung $book
 
 Die Operation zur Buchung eines Termins MUSS ebenfalls asynchron ausgeführt werden können, falls ein Termin-Repository keine Zusagen zu Antwortzeiten machen kann und somit das Problem besteht, dass der Client in einen Timeout läuft. Beispielsweise kann dies der Fall sein, wenn die Buchungsanfrage im Termin-Repository asynchrone Anfragen an andere Systeme auslöst und der Termin erst bestätigt werden kann, wenn diese durchgelaufen sind. Es gelten die Regeln der [FHIR Kernspezifikation - Abschnitt 3.2.0.7 Executing an Operation Asynchronously](https://www.hl7.org/fhir/r4/operations.html):

--- a/publisher-guides/Formular/input/pagecontent/FunktionenInteraktionen.md
+++ b/publisher-guides/Formular/input/pagecontent/FunktionenInteraktionen.md
@@ -133,3 +133,6 @@ In der aktuellen Ausbaustufe ist es von zentraler Bedeutung, dass das Narrative 
 Primärsysteme müssen in der aktuellen Stufe die strukturierten Anteile (FormularDaten und FormularDatenExtrakt) nicht übernehmen. Es wird jedoch empfohlen, das vollständige Bundle zu persistieren, sodass zu einem späteren Zeitpunkt, wenn eine Übernahme einzelner strukturierter Daten möglich ist, diese auch rückwirkend erfolgen kann.
 
 Weitere Details zu Interaktionen und Verarbeitung finden sich in [ISiK Basis: Datenübermittlung aus Subsystemen](https://simplifier.net/guide/isik-basis-stufe-5/Einfuehrung/UseCasesAnwendung/Daten%C3%BCbermittlung-aus-Subsystemen.page.md).
+
+#### Übbermittlung von FormularDaten außerhalb der "Datenübermittlung aus Subsystemen"
+In bestimmten Anwendungsfällen kann es erforderlich sein, die Rückübermittlung von FormularDaten auch außerhalb der in ISiK Basis Stufe-6 beschriebenen "Datenübermittlung aus Subsystemen" durchzuführen. In diesem Fall ist die Nutzung von `QuestionnaireResponse.text` erforderlich, um eine menschenlesbare Repräsentation der Daten zu übermitteln. 

--- a/publisher-guides/Formular/input/resources/StructureDefinition-ISiKFormularDaten.json
+++ b/publisher-guides/Formular/input/resources/StructureDefinition-ISiKFormularDaten.json
@@ -79,6 +79,13 @@
         "max": "0"
       },
       {
+        "id": "QuestionnaireResponse.text",
+        "path": "QuestionnaireResponse.text",
+        "short": "Menschlich lesbare Zusammenfassung der FormularDaten",
+        "comment": "**Begründung MS:**\n  Wird ein Formular nicht im Kontext der `Datenübermittlung aus Subsystemen` übertragen, wo ein Narrativ im Kontext der Composition gefordert wird, muss an dieser Stelle eine menschenlesbare Zusammenfassung der FormularDaten bereitgestellt werden, damit die Informationen auch ohne Zugriff auf die zugrunde liegende FormularDefinition und die strukturierte Darstellung der Formulardaten interpretiert werden können.",
+        "mustSupport": true
+      },
+      {
         "id": "QuestionnaireResponse.modifierExtension",
         "path": "QuestionnaireResponse.modifierExtension",
         "slicing": {

--- a/publisher-guides/Terminplanung/input/pagecontent/Operations.md
+++ b/publisher-guides/Terminplanung/input/pagecontent/Operations.md
@@ -246,6 +246,14 @@ Mindestens einer der nachfolgenden Wege MUSS unterstützt werden, um eine Patien
 - Übergabe innerhalb der `$book`-Operation:
   Das Termin-Repository unterstützt die Übergabe einer Patient-Instanz mittels des dafür vorgesehenen Parameters innerhalb der `$book`-Operation.
 
+### Übermittlung zusätzlicher Patientenangaben
+
+Zusätzlich KANN innerhalb der `$book`-Operation über den Parameter `patientSubmittedInformation` eine `QuestionnaireResponse`-Ressource übermittelt werden, um patientenseitig erhobene Angaben im Rahmen der Terminbuchung zu übertragen. Dies ermöglicht es insbesondere Portalsystemen, abhängig vom Anwendungsfall oder von der Terminart unterschiedliche Fragen zu stellen, ohne dass hierfür Änderungen an der Spezifikation erforderlich sind.
+
+Im ersten Ausbauschritt genügt es, wenn die `QuestionnaireResponse` die Fragen und Antworten selbst enthält. Eine Auflösung oder Mitlieferung der zugrundeliegenden `Questionnaire`-Definition ist hierfür nicht erforderlich. Das Element `QuestionnaireResponse.questionnaire` SOLL jedoch befüllt sein, damit unterschiedlich strukturierte Antworten unterschieden und perspektivisch automatisiert verarbeitet werden können. Das Element `QuestionnaireResponse.text` MUSS befüllt sein, damit die Inhalte durch das empfangende System unmittelbar dargestellt werden können.
+
+Die Vorgaben aus dem [ISiK-Formularmodul](https://gemspec.gematik.de/ig/fhir/isik/formularmodul/6.0.0-rc/index.html) sind für die `QuestionnaireResponse`-Ressource entsprechend anzuwenden, insbesondere hinsichtlich der Kodierung von Fragen und Antworten.  
+
 ### Asynchrone Ausführung $book
 
 Die Operation zur Buchung eines Termins MUSS ebenfalls asynchron ausgeführt werden können, falls ein Termin-Repository keine Zusagen zu Antwortzeiten machen kann und somit das Problem besteht, dass der Client in einen Timeout läuft. Beispielsweise kann dies der Fall sein, wenn die Buchungsanfrage im Termin-Repository asynchrone Anfragen an andere Systeme auslöst und der Termin erst bestätigt werden kann, wenn diese durchgelaufen sind. Es gelten die Regeln der [FHIR Kernspezifikation - Abschnitt 3.2.0.7 Executing an Operation Asynchronously](https://www.hl7.org/fhir/r4/operations.html):

--- a/publisher-guides/Terminplanung/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Terminplanung/input/pagecontent/ReleaseNotes.md
@@ -13,6 +13,7 @@ Datum: tbd.
 * `improve` Verpflichtende Einführung des Suchparameters `_lastUpdated`  https://github.com/gematik/spec-ISiK-Basismodul/pull/1053
 * `improve` Implicit Rules auf 0..0 beschränkt https://github.com/gematik/spec-ISiK-Basismodul/pull/1075
 * `improve` Erweiterung um Subscription Profil zur Abbildung der Veränderung/Absage eines Termins durch ein Termin Repository https://github.com/gematik/spec-ISiK-Basismodul/pull/1087
+* `improve` Beschreibung und Einordnung des `$book`-Parameters `patientSubmittedInformation` zur Übermittlung zusätzlicher Patientenangaben als `QuestionnaireResponse` ergänzt https://github.com/gematik/spec-ISiK-Basismodul/pull/1116
 
 
 ### Version 5.1.1

--- a/publisher-guides/Terminplanung/input/resources/OperationDefinition-ISiKAppointmentBookOperation.json
+++ b/publisher-guides/Terminplanung/input/resources/OperationDefinition-ISiKAppointmentBookOperation.json
@@ -84,6 +84,14 @@
       "type": "Patient"
     },
     {
+      "name": "patientSubmittedInformation",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "Dieser Parameter KANN durch einen Client und MUSS durch ein Termin-Repository unterstützt werden. Wird der Parameter unterstützt, dann gelten folgende Festlegungen: Eine QuestionnaireResponse-Ressource KANN übergeben werden, um patientenseitig erhobene Angaben im Rahmen der Terminbuchung zu übermitteln. Dies ermöglicht eine dynamische Ausgestaltung der $book-Operation für unterschiedliche Anwendungsfälle, ohne dass Änderungen an der Spezifikation erforderlich sind. Die Inhalte KÖNNEN insbesondere anamnestische Informationen, Angaben zum Bedarf an Mobilitätshilfen oder Übersetzungsleistungen sowie Bestätigungen zur Kenntnisnahme von Informationen oder zur Kostenübernahme umfassen. Das Portalsystem MUSS im ersten Ausbauschritt mindestens die Fragen und Antworten innerhalb der QuestionnaireResponse übermitteln; die zugrundeliegende Questionnaire-Definition MUSS nicht mitgeliefert oder durch das empfangende System aufgelöst werden. Das Element QuestionnaireResponse.questionnaire SOLL jedoch befüllt sein, damit unterschiedlich strukturierte QuestionnaireResponses unterschieden und perspektivisch automatisiert verarbeitet werden können. Das Element QuestionnaireResponse.text MUSS befüllt sein, damit die übermittelten Informationen durch das empfangende System unmittelbar gerendert werden können. Invalide Ressourcen MÜSSEN vom Termin-Repository abgelehnt werden (zur Form der Ablehnung s.u.).",
+      "type": "QuestionnaireResponse"
+    },
+    {
       "name": "return",
       "use": "out",
       "min": 0,


### PR DESCRIPTION
# Beschreibung

Dieser PR ergänzt die `$book`-Operation um die fachliche Beschreibung des neuen Parameters `patientSubmittedInformation` und dokumentiert dessen Verwendung zusätzlich in der Terminplanungs-Doku.

Ziel ist es, patientenseitig erhobene Zusatzinformationen strukturiert als `QuestionnaireResponse` im Rahmen der Terminbuchung zu übermitteln, ohne dafür die Spezifikation pro Use Case anpassen zu müssen.

# Änderungen

- Ergänzung der Beschreibung von `patientSubmittedInformation` in der OperationDefinition
- Festlegung, dass im ersten Ausbauschritt eine `QuestionnaireResponse` mit enthaltenen Fragen und Antworten ausreicht
- Festlegung, dass `QuestionnaireResponse.questionnaire` gesetzt sein soll, um unterschiedliche Strukturen unterscheiden und perspektivisch automatisiert verarbeiten zu können
- Festlegung, dass `QuestionnaireResponse.text` befüllt sein muss, damit die Inhalte empfangsseitig direkt dargestellt werden können
- Ergänzung der fachlichen Dokumentation in `Operations.page.md`
- Einführung eines eigenen Abschnitts für zusätzliche Patientenangaben, damit die Einordnung nicht unter der Überschrift zur Patient-Ressource vermischt wird
- Verweis auf die Anwendbarkeit der Vorgaben aus dem ISiK-Formularmodul für die `QuestionnaireResponse`

# Fachlicher Hintergrund

Portalsysteme sollen abhängig von Terminart oder Use Case zusätzliche Informationen vom Patienten abfragen können, zum Beispiel:

- anamnestische Angaben
- Bedarf an Mobilitätshilfen
- Bedarf an Übersetzungsleistungen
- Bestätigungen zur Kenntnisnahme von Hinweisen
- Bestätigungen zur Kostenübernahme

Im ersten Schritt wird bewusst kein verpflichtendes Auflösen oder Mitliefern der zugrundeliegenden `Questionnaire`-Definition verlangt. Damit bleibt die Integration einfach, während durch die gesetzte Canonical bereits eine spätere stärkere Automatisierung vorbereitet wird.

# Betroffene Dateien

- `Resources/input/fsh/Terminplanung/ISiKBookOperation.fsh`
- `guides/Terminplanung-5/Einfuehrung/Festlegungen/Operations.page.md`

# Test / Prüfung

- Inhaltliche Prüfung der FSH- und Markdown-Anpassungen
- Keine technische Testausführung erfolgt
