### PR TITLE
added missing MS to ISiKATCCoding

### DIFF
--- a/Resources/fsh-generated/resources/Condition-AkuteInfektionDerOberenAtemwege.json
+++ b/Resources/fsh-generated/resources/Condition-AkuteInfektionDerOberenAtemwege.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Condition",
-  "id": "MittelgradigeIntelligenzminderung",
+  "id": "AkuteInfektionDerOberenAtemwege",
   "meta": {
     "profile": [
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKDiagnose"
@@ -18,9 +18,9 @@
     "coding": [
       {
         "version": "2024",
-        "code": "F71",
+        "code": "J06.9",
         "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-        "display": "Mittelgradige Intelligenzminderung"
+        "display": "Akute Infektion der oberen Atemwege"
       }
     ]
   },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKATCCoding.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKATCCoding.json
@@ -26,6 +26,13 @@
         "mustSupport": true
       },
       {
+        "id": "Coding.version",
+        "path": "Coding.version",
+        "short": "Version",
+        "comment": "Motivation MS: Version des kodierten Wertes.",
+        "mustSupport": true
+      },
+      {
         "id": "Coding.code",
         "path": "Coding.code",
         "short": "Code",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -188,11 +188,6 @@
         "mustSupport": true
       },
       {
-        "id": "AllergyIntolerance.code.coding:atc.version",
-        "path": "AllergyIntolerance.code.coding.version",
-        "mustSupport": true
-      },
-      {
         "id": "AllergyIntolerance.code.text",
         "path": "AllergyIntolerance.code.text",
         "mustSupport": true

--- a/Resources/input/fsh/Basis/ISiKDataTypeProfiles.fsh
+++ b/Resources/input/fsh/Basis/ISiKDataTypeProfiles.fsh
@@ -71,6 +71,8 @@ Description: "Data Type profile for ATC Codings in ISiK"
 * insert Meta
 * system 1.. MS
   * insert Coding-System-MS
+* version MS
+  * insert Coding-Version-MS
 * code 1.. MS
   * insert Coding-Code-MS
 * display MS

--- a/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKATCCoding.json
+++ b/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKATCCoding.json
@@ -26,6 +26,13 @@
         "mustSupport": true
       },
       {
+        "id": "Coding.version",
+        "path": "Coding.version",
+        "short": "Version",
+        "comment": "Motivation MS: Version des kodierten Wertes.",
+        "mustSupport": true
+      },
+      {
         "id": "Coding.code",
         "path": "Coding.code",
         "short": "Code",

--- a/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -188,11 +188,6 @@
         "mustSupport": true
       },
       {
-        "id": "AllergyIntolerance.code.coding:atc.version",
-        "path": "AllergyIntolerance.code.coding.version",
-        "mustSupport": true
-      },
-      {
         "id": "AllergyIntolerance.code.text",
         "path": "AllergyIntolerance.code.text",
         "mustSupport": true

--- a/publisher-guides/Basis/input/resources/StructureDefinition-ISiKATCCoding.json
+++ b/publisher-guides/Basis/input/resources/StructureDefinition-ISiKATCCoding.json
@@ -26,6 +26,13 @@
         "mustSupport": true
       },
       {
+        "id": "Coding.version",
+        "path": "Coding.version",
+        "short": "Version",
+        "comment": "Motivation MS: Version des kodierten Wertes.",
+        "mustSupport": true
+      },
+      {
         "id": "Coding.code",
         "path": "Coding.code",
         "short": "Code",

--- a/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -188,11 +188,6 @@
         "mustSupport": true
       },
       {
-        "id": "AllergyIntolerance.code.coding:atc.version",
-        "path": "AllergyIntolerance.code.coding.version",
-        "mustSupport": true
-      },
-      {
         "id": "AllergyIntolerance.code.text",
         "path": "AllergyIntolerance.code.text",
         "mustSupport": true

--- a/publisher-guides/ICU/input/resources/StructureDefinition-ISiKATCCoding.json
+++ b/publisher-guides/ICU/input/resources/StructureDefinition-ISiKATCCoding.json
@@ -26,6 +26,13 @@
         "mustSupport": true
       },
       {
+        "id": "Coding.version",
+        "path": "Coding.version",
+        "short": "Version",
+        "comment": "Motivation MS: Version des kodierten Wertes.",
+        "mustSupport": true
+      },
+      {
         "id": "Coding.code",
         "path": "Coding.code",
         "short": "Code",

--- a/publisher-guides/ICU/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/ICU/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -188,11 +188,6 @@
         "mustSupport": true
       },
       {
-        "id": "AllergyIntolerance.code.coding:atc.version",
-        "path": "AllergyIntolerance.code.coding.version",
-        "mustSupport": true
-      },
-      {
         "id": "AllergyIntolerance.code.text",
         "path": "AllergyIntolerance.code.text",
         "mustSupport": true

--- a/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,11 @@
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+* `fix` Fehlendes MS zum ISiKATCCoding hinzugefügt, die Version war bisher schon 1..1, aber es fehlte die MS-Definition https://github.com/gematik/spec-ISiK-Basismodul/pull/1155
+
 ### Version 6.0.0-rc
 
 Datum: 02.04.2026

--- a/publisher-guides/Medikation/input/resources/StructureDefinition-ISiKATCCoding.json
+++ b/publisher-guides/Medikation/input/resources/StructureDefinition-ISiKATCCoding.json
@@ -26,6 +26,13 @@
         "mustSupport": true
       },
       {
+        "id": "Coding.version",
+        "path": "Coding.version",
+        "short": "Version",
+        "comment": "Motivation MS: Version des kodierten Wertes.",
+        "mustSupport": true
+      },
+      {
         "id": "Coding.code",
         "path": "Coding.code",
         "short": "Code",


### PR DESCRIPTION
Fehlendes MS zum ISiKATCCoding hinzugefügt, die Version war bisher schon 1..1, aber es fehlte die MS-Definition