### PR TITLE
Stufe 5/med/fix/ptdata 1872 - remove replaces extension

### DIFF
--- a/Resources/fsh-generated/resources/MedicationRequest-ExampleISiKMedikationsVerordnung2.json
+++ b/Resources/fsh-generated/resources/MedicationRequest-ExampleISiKMedikationsVerordnung2.json
@@ -6,14 +6,9 @@
       "https://gematik.de/fhir/isik/StructureDefinition/ISiKMedikationsVerordnung"
     ]
   },
-  "extension": [
-    {
-      "url": "https://gematik.de/fhir/isik/StructureDefinition/ExtensionISiKMedicationRequestReplaces",
-      "valueReference": {
-        "reference": "MedicationRequest/77777"
-      }
-    }
-  ],
+  "priorPrescription": {
+    "reference": "MedicationRequest/ExampleISiKMedikationsVerordnung"
+  },
   "status": "active",
   "intent": "order",
   "medicationReference": {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json
@@ -138,34 +138,6 @@
         "mustSupport": true
       },
       {
-        "id": "MedicationRequest.extension:medicationRequestReplaces",
-        "path": "MedicationRequest.extension",
-        "sliceName": "medicationRequestReplaces",
-        "short": "Welche Medikationsverordnung wird ersetzt?",
-        "comment": "Begründung des Must-Support: historische Nachvollziehbarkeit ersetzter Verordnungen.\n\n    Hinweis: Diese Extension dient der Abbildung einer Verordnung, die eine vorherige Medikation ersetzt - z.B. bei Unverträglichkeit, mangelnder Wirksamkeit oder Wechsel des Wirkstoffs.\n    Abgrenzung: Im Gegensatz zum Feld 'priorPrescription', das eine Folgeverordnung bei fortgesetzter Therapie beschreibt, kennzeichnet diese Extension eine bewusste Ablösung der ursprünglichen Verordnung.",
-        "min": 0,
-        "max": "1",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "https://gematik.de/fhir/isik/StructureDefinition/ExtensionISiKMedicationRequestReplaces"
-            ]
-          }
-        ],
-        "mustSupport": true
-      },
-      {
-        "id": "MedicationRequest.extension:medicationRequestReplaces.value[x]",
-        "path": "MedicationRequest.extension.value[x]",
-        "mustSupport": true
-      },
-      {
-        "id": "MedicationRequest.extension:medicationRequestReplaces.value[x].reference",
-        "path": "MedicationRequest.extension.value[x].reference",
-        "mustSupport": true
-      },
-      {
         "id": "MedicationRequest.status",
         "path": "MedicationRequest.status",
         "short": "Status der Verordnungsinformation",
@@ -1027,8 +999,9 @@
       {
         "id": "MedicationRequest.priorPrescription",
         "path": "MedicationRequest.priorPrescription",
-        "short": "Vorherige Verordnung bei fortgesetzter Therapie",
-        "comment": "Hinweis: Dieses Feld dient der Referenz auf eine frühere Verordnung, auf deren Basis die aktuelle Verschreibung fortgeführt wird - z.B. bei Folgerezepten.\n\n  Abgrenzung: Im Gegensatz zur Extension 'medicationRequestReplaces', die das Ersetzen einer Verordnung (z.B. bei Unverträglichkeit) abbildet, beschreibt 'priorPrescription' eine Fortführung einer bestehenden Medikation."
+        "short": "Vorherige Verordnung mit Bezug zur aktuellen Verordnung",
+        "comment": "Begründung des Must-Support: Erforderlich zur Abbildung des fachlichen Zusammenhangs zwischen Verordnungen (z. B. Fortführung, Änderung oder Ersetzung) und zur Nachvollziehbarkeit der Medikationshistorie.",
+        "mustSupport": true
       }
     ]
   }

--- a/Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh
+++ b/Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh
@@ -9,8 +9,7 @@ Description: "Dieses Profil ermöglicht die Abbildung von Medikationsverordnunge
 * extension contains
     ExtensionISiKAcceptedRisk named acceptedRisk 0..1 MS and
     ExtensionISiKMedikationsart named medikationsart 0..1 MS and
-    ExtensionISiKBehandlungsziel named behandlungsziel 0..1 MS and
-    ExtensionISiKMedicationRequestReplaces named medicationRequestReplaces 0..1 MS
+    ExtensionISiKBehandlungsziel named behandlungsziel 0..1 MS
 * extension[acceptedRisk]
   * ^short = "akzeptiertes (in Kauf genommenes) Risiko"
   * ^comment = "Begründung des Must-Support: Folgeinformation der AMTS-Bewertung, sollte auch an nachfolgende Behandelnde übermittelbar sein
@@ -32,14 +31,6 @@ Description: "Dieses Profil ermöglicht die Abbildung von Medikationsverordnunge
 
   Hinweis: Freitext-Beschreibung des Behandlungsziels."
   * valueString MS
-* extension[medicationRequestReplaces]
-  * ^short = "Welche Medikationsverordnung wird ersetzt?"
-  * ^comment = "Begründung des Must-Support: historische Nachvollziehbarkeit ersetzter Verordnungen.
-
-    Hinweis: Diese Extension dient der Abbildung einer Verordnung, die eine vorherige Medikation ersetzt - z.B. bei Unverträglichkeit, mangelnder Wirksamkeit oder Wechsel des Wirkstoffs.
-    Abgrenzung: Im Gegensatz zum Feld 'priorPrescription', das eine Folgeverordnung bei fortgesetzter Therapie beschreibt, kennzeichnet diese Extension eine bewusste Ablösung der ursprünglichen Verordnung."
-  * valueReference MS
-    * reference MS
 * status MS
   * ^short = "Status der Verordnungsinformation"
   * ^comment = "Begründung des Must-Support: Erforderliche Angabe im FHIR-Standard.
@@ -262,11 +253,9 @@ Begründung zu Must-Support: Konsolidierung mit MII Profil: https://www.medizini
   * ^short = "Ersatz zulässig"
   * ^comment = "Begründung des Must-Support: Alignment mit dem (E-)Rezept"
   * allowedBoolean MS
-* priorPrescription 
-  * ^short = "Vorherige Verordnung bei fortgesetzter Therapie"
-  * ^comment = "Hinweis: Dieses Feld dient der Referenz auf eine frühere Verordnung, auf deren Basis die aktuelle Verschreibung fortgeführt wird - z.B. bei Folgerezepten.
-
-  Abgrenzung: Im Gegensatz zur Extension 'medicationRequestReplaces', die das Ersetzen einer Verordnung (z.B. bei Unverträglichkeit) abbildet, beschreibt 'priorPrescription' eine Fortführung einer bestehenden Medikation."
+* priorPrescription MS 
+  * ^short = "Vorherige Verordnung mit Bezug zur aktuellen Verordnung"
+  * ^comment = "Begründung des Must-Support: Erforderlich zur Abbildung des fachlichen Zusammenhangs zwischen Verordnungen (z. B. Fortführung, Änderung oder Ersetzung) und zur Nachvollziehbarkeit der Medikationshistorie."
 
 Instance: ExampleISiKMedikationsVerordnung
 InstanceOf: ISiKMedikationsVerordnung
@@ -296,7 +285,7 @@ Usage: #example
 Instance: ExampleISiKMedikationsVerordnung2
 InstanceOf: ISiKMedikationsVerordnung
 Usage: #example
-* extension[medicationRequestReplaces].valueReference.reference = "MedicationRequest/77777"
+* priorPrescription = Reference(ExampleISiKMedikationsVerordnung)
 * status = #active
 * intent = #order
 * medicationReference = Reference(ExampleISiKMedikament8)

--- a/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
@@ -6,7 +6,7 @@ Datum: tbd
 
 * `fix` Hinzufügen der Rulesets `CommonSearchParameters` und `OptionalTagSearchParameter` zu den Rollen CapabilityStatements https://github.com/gematik/spec-ISiK-Basismodul/pull/1161 - analog zu TC 5.1.2 siehe https://github.com/gematik/spec-ISiK-Basismodul/pull/1158
 * `fix` Fehlendes MS zum ISiKATCCoding hinzugefügt, die Version war bisher schon 1..1, aber es fehlte die MS-Definition https://github.com/gematik/spec-ISiK-Basismodul/pull/1155
-* `improve` Entfernen der `replaces`-Extension (`extension.medicationRequestReplaces`) in der Medikation-Verordnung; stattdessen wird `MedicationRequest.priorPrescription` verwendet. ([chat.fhir.org](https://chat.fhir.org/#narrow/channel/179166-implementers/topic/Definition.20of.20MedicationRequest.2EpriorPrescription/with/542711071)) 
+* `improve` Entfernen der `replaces`-Extension (`extension.medicationRequestReplaces`) in der Medikation-Verordnung; stattdessen wird `MedicationRequest.priorPrescription` verwendet. ([chat.fhir.org](https://chat.fhir.org/#narrow/channel/179166-implementers/topic/Definition.20of.20MedicationRequest.2EpriorPrescription/with/542711071)) https://github.com/gematik/spec-ISiK-Basismodul/pull/1191
 
 ### Version 6.0.0-rc
 

--- a/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
@@ -6,6 +6,7 @@ Datum: tbd
 
 * `fix` Hinzufügen der Rulesets `CommonSearchParameters` und `OptionalTagSearchParameter` zu den Rollen CapabilityStatements https://github.com/gematik/spec-ISiK-Basismodul/pull/1161 - analog zu TC 5.1.2 siehe https://github.com/gematik/spec-ISiK-Basismodul/pull/1158
 * `fix` Fehlendes MS zum ISiKATCCoding hinzugefügt, die Version war bisher schon 1..1, aber es fehlte die MS-Definition https://github.com/gematik/spec-ISiK-Basismodul/pull/1155
+* `improve` Entfernen der `replaces`-Extension (`extension.medicationRequestReplaces`) in der Medikation-Verordnung; stattdessen wird `MedicationRequest.priorPrescription` verwendet. ([chat.fhir.org](https://chat.fhir.org/#narrow/channel/179166-implementers/topic/Definition.20of.20MedicationRequest.2EpriorPrescription/with/542711071)) 
 
 ### Version 6.0.0-rc
 


### PR DESCRIPTION
This pull request refactors how the replacement or continuation of medication prescriptions is represented in the ISiK MedicationRequest profile. The custom extension for replaced prescriptions (`medicationRequestReplaces`) is removed, and the standard FHIR field `priorPrescription` is now used for all references to previous prescriptions. Documentation and examples have been updated accordingly.

Key changes:

**FHIR Profile and Extension Structure:**

* Removed the `ExtensionISiKMedicationRequestReplaces` extension from the ISiK MedicationRequest profile and all related definitions, comments, and must-support flags. [[1]](diffhunk://#diff-996e2e92f8d6912ab071444fcffdde2386959a62da4ad959677c4fdfea76f92dL12-R12) [[2]](diffhunk://#diff-996e2e92f8d6912ab071444fcffdde2386959a62da4ad959677c4fdfea76f92dL35-L42) [[3]](diffhunk://#diff-03cebd27efb0450c38aaf3867373715d9ac3544f4dca76ad6d86dee50d91631aL140-L167)
* Updated the `priorPrescription` field to be must-support and clarified its use to cover all cases of referencing previous prescriptions, including replacements and continuations. [[1]](diffhunk://#diff-996e2e92f8d6912ab071444fcffdde2386959a62da4ad959677c4fdfea76f92dL265-R258) [[2]](diffhunk://#diff-03cebd27efb0450c38aaf3867373715d9ac3544f4dca76ad6d86dee50d91631aL1030-R1004)

**Example and Resource Updates:**

* Updated example resource `MedicationRequest-ExampleISiKMedikationsVerordnung2.json` to use `priorPrescription` instead of the removed extension. [[1]](diffhunk://#diff-4544b143c2968bc9fa17ac1dc0b0d2c84a3085f259f644ede14d2bfda730b608L9-R11) [[2]](diffhunk://#diff-996e2e92f8d6912ab071444fcffdde2386959a62da4ad959677c4fdfea76f92dL299-R288)

**Documentation:**

* Added a release note about the removal of the `replaces` extension in favor of `priorPrescription`.