### PR TITLE
feat: add guidance links to medication ig for Bedarfsmedikation and Infusionen in new markdown files

### DIFF
--- a/publisher-guides/Medikation/fsh-generated/includes/menu.xml
+++ b/publisher-guides/Medikation/fsh-generated/includes/menu.xml
@@ -25,6 +25,12 @@
         <a href="UebersichtAnwendungsfaelle.html">Übersicht Anwendungsfälle (Use Cases)</a>
       </li>
       <li>
+        <a href="Bedarfsmedikation.html">Bedarfsmedikation</a>
+      </li>
+      <li>
+        <a href="Infusionen.html">Infusionen</a>
+      </li>
+      <li>
         <a href="Informationsmodell.html">Informationsmodell</a>
       </li>
     </ul>

--- a/publisher-guides/Medikation/fsh-generated/resources/ImplementationGuide-medikation.json
+++ b/publisher-guides/Medikation/fsh-generated/resources/ImplementationGuide-medikation.json
@@ -946,6 +946,16 @@
           "generation": "markdown"
         },
         {
+          "nameUrl": "Bedarfsmedikation.html",
+          "title": "Bedarfsmedikation",
+          "generation": "markdown"
+        },
+        {
+          "nameUrl": "Infusionen.html",
+          "title": "Infusionen",
+          "generation": "markdown"
+        },
+        {
           "nameUrl": "Informationsmodell.html",
           "title": "Informationsmodell",
           "generation": "markdown"

--- a/publisher-guides/Medikation/input/pagecontent/Bedarfsmedikation.md
+++ b/publisher-guides/Medikation/input/pagecontent/Bedarfsmedikation.md
@@ -1,0 +1,3 @@
+# Bedarfsmedikation
+
+Die Abbildung und fachliche Spezifikation von Bedarfsmedikation wird derzeit im Implementierungsleitfaden [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) erarbeitet. Die dort beschriebenen Konzepte und Festlegungen können als fachliche und technische Guidance für die Umsetzung von Bedarfsmedikation im Kontext dieses Implementierungsleitfadens herangezogen werden.

--- a/publisher-guides/Medikation/input/pagecontent/Infusionen.md
+++ b/publisher-guides/Medikation/input/pagecontent/Infusionen.md
@@ -1,0 +1,3 @@
+# Infusionen
+
+Die Abbildung und fachliche Spezifikation von Infusionen wird derzeit im Implementierungsleitfaden [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) erarbeitet. Die dort beschriebenen Konzepte und Festlegungen können als fachliche und technische Guidance für die Umsetzung von Infusionen im Kontext dieses Implementierungsleitfadens herangezogen werden.

--- a/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
@@ -168,7 +168,7 @@ Datum: 04.04.2024
 Datum: 08.01.2024
 
 * workflow improvement regarding image rendering and display
-* `improve` Update dependency with Basis:  https://github.com/gematik/spec-ISiK-Medikation/pull/102/commits/039654b03d5b159ed258c35b48c37cd2db3e4a81
+* `improve` Update dependency with Basis: https://github.com/gematik/spec-ISiK-Medikation/pull/102/commits/039654b03d5b159ed258c35b48c37cd2db3e4a81
 * `improve` sentence on ISIKBasis Ressource usage by @f-peverali in https://github.com/gematik/spec-ISiK-Medikation/pull/103
 ----
 ### Version: 3.0.0

--- a/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
@@ -7,6 +7,7 @@ Datum: tbd
 * `fix` Hinzufügen der Rulesets `CommonSearchParameters` und `OptionalTagSearchParameter` zu den Rollen CapabilityStatements https://github.com/gematik/spec-ISiK-Basismodul/pull/1161 - analog zu TC 5.1.2 siehe https://github.com/gematik/spec-ISiK-Basismodul/pull/1158
 * `fix` Fehlendes MS zum ISiKATCCoding hinzugefügt, die Version war bisher schon 1..1, aber es fehlte die MS-Definition https://github.com/gematik/spec-ISiK-Basismodul/pull/1155
 * `improve` Entfernen der `replaces`-Extension (`extension.medicationRequestReplaces`) in Medikation-Verordnung und Medikation-Statement; in der Medikation-Verordnung wird stattdessen `MedicationRequest.priorPrescription` verwendet. ([chat.fhir.org](https://chat.fhir.org/#narrow/channel/179166-implementers/topic/Definition.20of.20MedicationRequest.2EpriorPrescription/with/542711071)) https://github.com/gematik/spec-ISiK-Basismodul/pull/1192
+* `documentation` Neue Use-Case-Seiten `Bedarfsmedikation` und `Infusionen` im Menü ergänzt <https://github.com/gematik/spec-ISiK-Basismodul/pull/1204>
 
 ### Version 6.0.0-rc
 

--- a/publisher-guides/Medikation/sushi-config.yaml
+++ b/publisher-guides/Medikation/sushi-config.yaml
@@ -33,6 +33,10 @@ pages:
     title: Release Notes
   UebersichtAnwendungsfaelle.md:
     title: Übersicht Anwendungsfälle  
+  Bedarfsmedikation.md:
+    title: Bedarfsmedikation
+  Infusionen.md:
+    title: Infusionen
   Informationsmodell.md:
     title: Informationsmodell
   UebergreifendeFestlegungen.md:
@@ -52,6 +56,8 @@ menu:
   Release Notes: ReleaseNotes.html
   Use Cases:
     Übersicht Anwendungsfälle (Use Cases): UebersichtAnwendungsfaelle.html
+    Bedarfsmedikation: Bedarfsmedikation.html
+    Infusionen: Infusionen.html
     Informationsmodell: Informationsmodell.html
   Übergreifende Festlegungen:
     Übergreifende Festlegungen: UebergreifendeFestlegungen.html


### PR DESCRIPTION
This pull request adds documentation for two new topics, "Bedarfsmedikation" (as-needed medication) and "Infusionen" (infusions), to the medication implementation guide. It also updates the navigation structure to include these new sections.

Documentation additions:

* Added new page `Bedarfsmedikation.md` describing the current status and guidance for as-needed medication, referencing the FHIR Medication IG Deutschland.
* Added new page `Infusionen.md` describing the current status and guidance for infusions, referencing the FHIR Medication IG Deutschland.

Navigation updates:

* Updated `sushi-config.yaml` to include "Bedarfsmedikation" and "Infusionen" in both the pages and menu sections, making these topics accessible in the documentation navigation. [[1]](diffhunk://#diff-ad1652ab0056b31748dc2edb172a3c45ee087f7b6e8e4a1e3aa3d27b3b32df2eR36-R39) [[2]](diffhunk://#diff-ad1652ab0056b31748dc2edb172a3c45ee087f7b6e8e4a1e3aa3d27b3b32df2eR59-R60)