### PR TITLE
Stufe 5: REQUIRED Suchparameter onset aus AMTS-Rolle und GesundheitsstatusRolle entfernt

### DIFF
--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementAMTSRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementAMTSRolle.json
@@ -269,22 +269,10 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "onset",
+              "name": "date",
               "type": "date",
               "documentation": "**Beispiel:** Suche nach allen Patienten, die eine Observation  mit dem Code '1234-5' haben\n        `GET [base]/Patient?_has:Observation:patient:code=1234-5`\n        **Beispiel:** Suche nach allen Encountern, bei denen die Diagnose 'A12.3' gestellt wurde\n        `GET [base]/Encounter?_has:Condition:encounter:code=A12.3`\n        **Anwendungshinweis:**\n        Weitere Details siehe FHIR-Kernspezifikation, Abschnitt [Reverse Chaining](https://hl7.org/fhir/R4/search.html#has).  ",
-              "definition": "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-onset"
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
-                }
-              ],
-              "name": "date",
-              "definition": "http://hl7.org/fhir/SearchParameter/conformance-date",
-              "type": "date",
-              "documentation": "**Beispiel:**\n        `GET [base]/[Resourcetype]?_tag=https://example.org/codes|needs-review`\n        **Anwendungshinweis:**\n        Weitere Details siehe FHIR-Kernspezifikation, Abschnitt [Parameters for all resources](https://hl7.org/fhir/R4/search.html#all)\n        sowie Abschnitt [Tags](https://www.hl7.org/fhir/R4/resource.html#simple-tags).  "
+              "definition": "http://hl7.org/fhir/SearchParameter/conformance-date"
             },
             {
               "extension": [
@@ -295,7 +283,8 @@
               ],
               "name": "_profile",
               "definition": "http://hl7.org/fhir/SearchParameter/Resource-profile",
-              "type": "uri"
+              "type": "uri",
+              "documentation": "**Beispiel:**\n        `GET [base]/[Resourcetype]?_tag=https://example.org/codes|needs-review`\n        **Anwendungshinweis:**\n        Weitere Details siehe FHIR-Kernspezifikation, Abschnitt [Parameters for all resources](https://hl7.org/fhir/R4/search.html#all)\n        sowie Abschnitt [Tags](https://www.hl7.org/fhir/R4/resource.html#simple-tags).  "
             },
             {
               "extension": [

--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementGesundheitsstatusRolle.json
@@ -450,18 +450,6 @@
                   "valueCode": "SHALL"
                 }
               ],
-              "name": "onset",
-              "definition": "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-onset",
-              "type": "date",
-              "documentation": "**Beispiel:**    \n          `GET [base]/AllergyIntolerance?onset=2015-01-01T12:00:23+02:00`    \n          **Anwendungshinweis:**   \n          Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#date).  "
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
-                }
-              ],
               "name": "date",
               "definition": "http://hl7.org/fhir/SearchParameter/conformance-date",
               "type": "date",

--- a/Resources/input/fsh/Basis/Rollen/ISiKCapabilityStatementGesundheitsstatusRolle.fsh
+++ b/Resources/input/fsh/Basis/Rollen/ISiKCapabilityStatementGesundheitsstatusRolle.fsh
@@ -203,16 +203,6 @@ Diese Rolle beschreibt verpflichtende Interaktionen zum Abruf und der Verarbeitu
           Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#reference).  " */
     * searchParam[+]
       * insert Expectation(#SHALL)
-      * name = "onset"
-      * definition = "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-onset"
-      * type = #date
-      * documentation = 
-          "**Beispiel:**    
-          `GET [base]/AllergyIntolerance?onset=2015-01-01T12:00:23+02:00`    
-          **Anwendungshinweis:**   
-          Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#date).  "
-    * searchParam[+]
-      * insert Expectation(#SHALL)
       * name = "date"
       * definition = "http://hl7.org/fhir/SearchParameter/conformance-date"
       * type = #date

--- a/Resources/input/fsh/Medikation/Rollen/ISiKCapabilityStatementAMTSRolle.fsh
+++ b/Resources/input/fsh/Medikation/Rollen/ISiKCapabilityStatementAMTSRolle.fsh
@@ -173,13 +173,6 @@ Usage: #definition
       * extension
         * url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
         * valueCode = #SHALL
-      * name = "onset"
-      * definition = "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-onset"
-      * type = #date
-    * searchParam[+]
-      * extension
-        * url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
-        * valueCode = #SHALL
       * name = "date"
       * definition = "http://hl7.org/fhir/SearchParameter/conformance-date"
       * type = #date

--- a/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
@@ -18,6 +18,10 @@ Die Tags werden folgendermaßen verwendet:
 
 - 'fix' sollte nur verwendet werden für Behebung von **Fehlern** an den (potentiell) normativen Inhalten der Spec (Anforderungen + Profile + CpS); Typo fixes werden nicht in die Releasenotes aufgenommen.
 
+## tbd
+
+* `fix` REQUIRED Suchparameter AllergyIntolerance.onset aus AMTS-Rolle und GesundheitsstatusRolle entfernt aufgrund fehlerhafter Spezifikation https://github.com/gematik/spec-ISiK-Basismodul/pull/1212
+
 ## Version 5.1.2
 
 Datum: 30.04.2026

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -4,6 +4,12 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von Releases. Die dritte Ziffer Y (Release x.0.y) bezeichnet eine technische Korrektur und versioniert kleinere Änderungen (Packages) während eines Jahres, z. B. 1.0.1.
 
+## Version 
+
+Datum: tbd
+
+* `fix` REQUIRED Suchparameter AllergyIntolerance.onset aus AMTS-Rolle entfernt aufgrund fehlerhafter Spezifikation https://github.com/gematik/spec-ISiK-Basismodul/pull/1212
+
 ## Version 5.1.2
 
 Datum: 30.04.2026


### PR DESCRIPTION
https://github.com/gematik/poc-isik-general/issues/5

REQUIRED Suchparameter onset aus AMTS-Rolle und GesundheitsstatusRolle entfernt, da FHIRPath-Expression fehlerhaft (Typ dateTime, zielt aber auch einen ChoiceType, der u.a. auch age und string enthalten kann)