### PR TITLE
Entfernung des MS-Flags bei Encounter.reason aufgrund unzureichender Spezifikation

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/Resources/input/fsh/Basis/ISiKKontaktGesundheitseinrichtung.fsh
+++ b/Resources/input/fsh/Basis/ISiKKontaktGesundheitseinrichtung.fsh
@@ -213,9 +213,10 @@ nach § 301 Abs. 3 SGB V. Somit sind diese über den Kontakt und nicht über den
     * ^comment = "Hier ist stets das *tatsächliche* Entlassdatum anzugeben.
     *Geplante* Entlassdaten müssen über die Extension `plannedEndDate` erfasst werden."
   
-* reasonCode MS
+* reasonCode 
   * ^short = "Grund des Aufenthalts"
-  * ^comment = "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR)."
+  * ^comment = "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. 
+Wegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
 * diagnosis 
   * ^short = "Falldiagnosen/-prozeduren"
   * ^comment = "Verweis auf Diagnosen/Prozeduren, die eine besondere Rolle im Kontext eines Encounters einnehmen, z.B. 'Aufnahmediagnose'   

--- a/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -11,7 +11,7 @@ Tags werden folgendermaßen verwendet:
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: tbd
-
+* `fix` Entfernung des MS-Flags bei Encounter.reason aufgrund unzureichender Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis <https://github.com/gematik/spec-ISiK-Basismodul/pull/1213>
 * `fix` Ableitung des Profils `ISiKOrganisationFachabteilung` vom Profil `ISiKOrganisation` wurde integriert <https://github.com/gematik/spec-ISiK-Basismodul/pull/1166>
 * `fix` Anpassung des Pattern/ ValueSet-Bindings auf Observation.code in den Profilen `ISiKSchwangerschaftErwarteterEntbindungstermin` und `ISiKSchwangerschaftsstatus` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1149>
 * `fix` Bei Test-Terminologien wurde das experimental Flag ergänzt <https://github.com/gematik/spec-ISiK-Basismodul/pull/1163>

--- a/publisher-guides/Basis/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/Basis/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/publisher-guides/ICU/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/ICU/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/publisher-guides/Medikation/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/Medikation/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/publisher-guides/Organspendeerkennung/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/Organspendeerkennung/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/publisher-guides/Terminplanung/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/Terminplanung/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",

--- a/publisher-guides/Vitalparameter/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
+++ b/publisher-guides/Vitalparameter/input/resources/StructureDefinition-ISiKKontaktGesundheitseinrichtung.json
@@ -523,8 +523,7 @@
         "id": "Encounter.reasonCode",
         "path": "Encounter.reasonCode",
         "short": "Grund des Aufenthalts",
-        "comment": "**Begründung MS:** Harmonisierung mit dem HL7 Europe Hospital Discharge Report (HDR).",
-        "mustSupport": true
+        "comment": "**Historie:** Aufgrund von Harmonisierungsbestrebungen mit dem HL7 Europe Hospital Discharge Report (HDR) in der Ballot-Version von Stufe 6 als MS deklariert. \nWegen der unzureichenden Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis wieder entfernt, bis zur Herbeiführung einer Klärung mit HL7 Europe."
       },
       {
         "id": "Encounter.diagnosis",


### PR DESCRIPTION
Entfernung des MS-Flags bei Encounter.reason aufgrund unzureichender Spezifikation und Abgrenzung zur Aufnahmediagnose in Encounter.diagnosis
https://github.com/gematik/poc-isik-general/issues/14