### PR TITLE
chore: update de.fhir.medication version to 1.0.7 in configuration files

### DIFF
--- a/Resources/sushi-config.yaml
+++ b/Resources/sushi-config.yaml
@@ -12,4 +12,4 @@ dependencies:
   hl7.fhir.uv.sdc: 4.0.0
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
-  de.fhir.medication: 1.0.4
+  de.fhir.medication: 1.0.7

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "hl7.fhir.uv.sdc": "4.0.0",
     "de.gematik.terminology": "1.0.6",
     "de.gematik.ti": "1.3.1",
-    "de.fhir.medication": "1.0.4",
+    "de.fhir.medication": "1.0.7",
     "de.medizininformatikinitiative.kerndatensatz.base": "2026.0.0",
     "de.medizininformatikinitiative.kerndatensatz.meta": "2026.0.0"
   },


### PR DESCRIPTION
This pull request updates the version of the `de.fhir.medication` dependency from `1.0.4` to `1.0.7` in both the `Resources/sushi-config.yaml` and `package.json` files to ensure consistency and to incorporate the latest improvements or fixes from the dependency.

Dependency updates:

* Updated `de.fhir.medication` version from `1.0.4` to `1.0.7` in `Resources/sushi-config.yaml` to use the latest release.
* Updated `de.fhir.medication` version from `1.0.4` to `1.0.7` in `package.json` for alignment and consistency.