### PR TITLE
Stufe 5/med/feature/ptdata 2250 as needed documentation

### DIFF
--- a/Resources/fsh-generated/resources/MedicationRequest-ExampleISiKMedikationsVerordnungBedarfsmedikation.json
+++ b/Resources/fsh-generated/resources/MedicationRequest-ExampleISiKMedikationsVerordnungBedarfsmedikation.json
@@ -1,0 +1,83 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "ExampleISiKMedikationsVerordnungBedarfsmedikation",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/isik/StructureDefinition/ISiKMedikationsVerordnung"
+    ]
+  },
+  "extension": [
+    {
+      "url": "https://gematik.de/fhir/isik/StructureDefinition/ExtensionISiKMedikationsart",
+      "valueCoding": {
+        "code": "akut",
+        "system": "https://gematik.de/fhir/isik/CodeSystem/ISiKMedikationsartCS"
+      }
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/11000274103/version/20251115",
+                "code": "76948002",
+                "display": "Starke Schmerzen"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/11000274103/version/20251115",
+                "code": "50415004",
+                "display": "Moderate Schmerzen"
+              }
+            ]
+          }
+        }
+      ],
+      "asNeededBoolean": true,
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 6,
+          "periodUnit": "h"
+        }
+      },
+      "doseAndRate": [
+        {
+          "doseQuantity": {
+            "value": 1,
+            "unit": "Tablette",
+            "system": "http://unitsofmeasure.org",
+            "code": "1"
+          }
+        }
+      ]
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationReference": {
+    "reference": "Medication/ExampleISiKMedikament1"
+  },
+  "subject": {
+    "reference": "Patient/PatientinMusterfrau"
+  },
+  "encounter": {
+    "reference": "Encounter/Fachabteilungskontakt"
+  },
+  "authoredOn": "2026-04-24",
+  "requester": {
+    "reference": "Practitioner/PractitionerWalterArzt"
+  }
+}

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedikationsVerordnung.json
@@ -445,7 +445,73 @@
             ]
           }
         ],
+        "constraint": [
+          {
+            "key": "isik-dosage-as-needed-for",
+            "severity": "error",
+            "human": "Wenn Indikationen für eine Bedarfsmedikation (asNeededFor) angegeben sind, MUSS asNeededBoolean vorhanden und 'true' sein.",
+            "expression": "extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor').empty() or asNeededBoolean = true",
+            "source": "https://gematik.de/fhir/isik/StructureDefinition/ISiKMedikationsVerordnung"
+          }
+        ],
         "mustSupport": true
+      },
+      {
+        "id": "MedicationRequest.dosageInstruction.extension",
+        "path": "MedicationRequest.dosageInstruction.extension",
+        "short": "Indikation(en) für die Bedarfsmedikation",
+        "comment": "Ermöglicht die Angabe mehrerer Indikationen für die Bedarfsmedikation, z. B. 'Schmerzen', 'Fieber', 'Hustenreiz' etc. Diese Bedingungen sind ODER-verknüpft, d. h. die Bedarfsmedikation soll bei Vorliegen einer ODER mehrerer dieser Bedingungen angewendet werden.\n\n  **Hinweis:** Dieses Element ist in diesem Modul (ISiK-Stufe 5) bewusst NICHT als Must-Support gekennzeichnet. Ab ISiK-Stufe 6 ist dieses Element mit Must-Support versehen."
+      },
+      {
+        "id": "MedicationRequest.dosageInstruction.extension.extension",
+        "path": "MedicationRequest.dosageInstruction.extension.extension",
+        "max": "0"
+      },
+      {
+        "id": "MedicationRequest.dosageInstruction.extension.value[x]",
+        "path": "MedicationRequest.dosageInstruction.extension.value[x]",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "type",
+              "path": "$this"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
+        "id": "MedicationRequest.dosageInstruction.extension.value[x]:valueCodeableConcept",
+        "path": "MedicationRequest.dosageInstruction.extension.value[x]",
+        "sliceName": "valueCodeableConcept",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ]
+      },
+      {
+        "id": "MedicationRequest.dosageInstruction.extension.value[x]:valueCodeableConcept.text",
+        "path": "MedicationRequest.dosageInstruction.extension.value[x].text",
+        "short": "Indikation für die Bedarfsmedikation (Freitext)"
+      },
+      {
+        "id": "MedicationRequest.dosageInstruction.extension:asNeededFor",
+        "path": "MedicationRequest.dosageInstruction.extension",
+        "sliceName": "asNeededFor",
+        "min": 0,
+        "max": "*",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor"
+            ]
+          }
+        ]
       },
       {
         "id": "MedicationRequest.dosageInstruction.text",
@@ -603,24 +669,8 @@
       {
         "id": "MedicationRequest.dosageInstruction.asNeeded[x]",
         "path": "MedicationRequest.dosageInstruction.asNeeded[x]",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "type",
-              "path": "$this"
-            }
-          ],
-          "ordered": false,
-          "rules": "open"
-        }
-      },
-      {
-        "id": "MedicationRequest.dosageInstruction.asNeeded[x]:asNeededBoolean",
-        "path": "MedicationRequest.dosageInstruction.asNeeded[x]",
-        "sliceName": "asNeededBoolean",
-        "short": "Bedarfsmedikation",
-        "min": 0,
-        "max": "1",
+        "short": "Bedarfsmedikation (ja/nein)",
+        "comment": "Begründung des Must-Support: Abbildung einer Bedarfsmedikation.",
         "type": [
           {
             "code": "boolean"

--- a/Resources/fsh-generated/resources/StructureDefinition-extension-Dosage.asNeededFor.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-extension-Dosage.asNeededFor.json
@@ -1,0 +1,58 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "extension-Dosage.asNeededFor",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+      "valueCode": "fhir"
+    }
+  ],
+  "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor",
+  "version": "5.1.2",
+  "name": "DosageAsNeededFor",
+  "title": "Dosage AsNeededFor",
+  "status": "active",
+  "experimental": false,
+  "date": "2026-04-30",
+  "publisher": "gematik GmbH",
+  "description": "R5 Backport-Extension zur Angabe einer oder mehrerer Bedingungen, unter denen eine Bedarfsmedikation angewendet werden soll.",
+  "fhirVersion": "4.0.1",
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Dosage"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "max": "0"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ],
+        "binding": {
+          "strength": "example",
+          "valueSet": "http://hl7.org/fhir/ValueSet/medication-as-needed-reason"
+        }
+      }
+    ]
+  }
+}

--- a/Resources/input/fsh/Medikation/ExtensionDosageAsNeededFor.fsh
+++ b/Resources/input/fsh/Medikation/ExtensionDosageAsNeededFor.fsh
@@ -1,0 +1,13 @@
+Extension: DosageAsNeededFor
+Id: extension-Dosage.asNeededFor
+Title: "Dosage AsNeededFor"
+Description: "R5 Backport-Extension zur Angabe einer oder mehrerer Bedingungen, unter denen eine Bedarfsmedikation angewendet werden soll."
+* insert Meta
+* ^url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor"
+* ^status = #active
+* ^context[0].type = #element
+* ^context[=].expression = "Dosage"
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-wg].valueCode = #fhir
+* extension 0..0
+* value[x] only CodeableConcept
+* valueCodeableConcept from http://hl7.org/fhir/ValueSet/medication-as-needed-reason (example)

--- a/Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh
+++ b/Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh
@@ -131,7 +131,8 @@ Begründung zu Must-Support: Konsolidierung mit MII Profil: https://www.medizini
   **Hinweis:** Zahlreiche [Beispiele zur Dosierungsanweisung sind im Implementierungsleitfaden Medikament von HL7 Deutschland](https://ig.fhir.de/igs/medication/dosierung-beispiele.html) dokumentiert.
   "
 * dosageInstruction only DosageDE
-  * text 
+* dosageInstruction obeys isik-dosage-as-needed-for
+  * text
     * ^comment = "Festlegung zum Must-Support: Die Verarbeitung MUSS unterstützt werden, indem empfangende Systeme  die Freitext-Dosierungsinformation entweder direkt in der Textform persistieren, ODER die Informationen in eine alternative (strukturierte) Form umwandeln (ggf. unter Einwirkung geeigneter Nutzer). Im letzteren Fall KANN auf eine Persistierung in Textform verzichtet werden, um Inkonsistenzen zu vermeiden.
         
     Ein System KANN jedoch strukturierte Dosierungsinformationen in Freitext-Dosierungsinformationen umwandeln, um sie in einem Dokument oder einer Benutzeroberfläche anzuzeigen - dabei ist auf Konsistenzwahrung zu allen strukturierten Elementen zu achten.
@@ -185,8 +186,19 @@ Begründung zu Must-Support: Konsolidierung mit MII Profil: https://www.medizini
         * ^short = "Tageszeitpunkt codiert"
       * offset MS
         * ^short = "zeitlicher Abstand der Gabe zum beschriebenen Zeitpunkt"
-  * asNeededBoolean MS
+  * asNeeded[x] only boolean
     * ^short = "Bedarfsmedikation"
+    * ^comment = "Begründung der Einschränkung auf boolean: Für die Angabe der Bedingung(en) wird die R5-Backport-Extension 'asNeededFor' genutzt, um mehrere ODER-verknüpfte Bedarfsbedingungen angeben zu können. Im Unterschied zu 'asNeededCodeableConcept' (Kardinalität 0..1) lassen sich damit mehrere bedingte Bedarfe (z. B. mittlere UND schwere Schmerzen) kodieren."
+  * asNeededBoolean MS
+    * ^short = "Bedarfsmedikation (ja/nein)"
+    * ^comment = "Begründung des Must-Support: Abbildung einer Bedarfsmedikation."
+  * extension contains $ext-dosage-as-needed-for named asNeededFor 0..*
+    * ^short = "Indikation(en) für die Bedarfsmedikation"
+    * ^comment = "Ermöglicht die Angabe mehrerer Indikationen für die Bedarfsmedikation, z. B. 'Schmerzen', 'Fieber', 'Hustenreiz' etc. Diese Bedingungen sind ODER-verknüpft, d. h. die Bedarfsmedikation soll bei Vorliegen einer ODER mehrerer dieser Bedingungen angewendet werden.
+
+  **Hinweis:** Dieses Element ist in diesem Modul (ISiK-Stufe 5) bewusst NICHT als Must-Support gekennzeichnet. Ab ISiK-Stufe 6 ist dieses Element mit Must-Support versehen."
+    * valueCodeableConcept.text
+      * ^short = "Indikation für die Bedarfsmedikation (Freitext)"
   * site MS
     * ^short = "Körperstelle der Verabreichung"
     * coding MS
@@ -266,6 +278,11 @@ Begründung zu Must-Support: Konsolidierung mit MII Profil: https://www.medizini
 
   Abgrenzung: Im Gegensatz zur Extension 'medicationRequestReplaces', die das Ersetzen einer Verordnung (z.B. bei Unverträglichkeit) abbildet, beschreibt 'priorPrescription' eine Fortführung einer bestehenden Medikation."
 
+Invariant: isik-dosage-as-needed-for
+Description: "Wenn Indikationen für eine Bedarfsmedikation (asNeededFor) angegeben sind, MUSS asNeededBoolean vorhanden und 'true' sein."
+Severity: #error
+Expression: "extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor').empty() or asNeededBoolean = true"
+
 Instance: ExampleISiKMedikationsVerordnung
 InstanceOf: ISiKMedikationsVerordnung
 Usage: #example
@@ -315,3 +332,38 @@ Usage: #example
     * unit = "ml Infusionslösung"
     * system = $cs-ucum
     * code = #mL
+
+Instance: ExampleISiKMedikationsVerordnungBedarfsmedikation
+InstanceOf: ISiKMedikationsVerordnung
+Usage: #example
+* extension[medikationsart].valueCoding = ISiKMedikationsartCS#akut
+* status = #active
+* intent = #order
+* medicationReference.reference = "Medication/ExampleISiKMedikament1"
+* subject = Reference(PatientinMusterfrau)
+* encounter.reference = "Encounter/Fachabteilungskontakt"
+* authoredOn = 2026-04-24
+* requester.reference = "Practitioner/PractitionerWalterArzt"
+* dosageInstruction
+  * asNeededBoolean = true
+  * timing.repeat
+    * frequency = 1
+    * period = 6
+    * periodUnit = #h
+  * extension[asNeededFor][+]
+    * valueCodeableConcept.coding[0]
+      * system = $cs-sct
+      * version = "http://snomed.info/sct/11000274103/version/20251115"
+      * code = #76948002
+      * display = "Starke Schmerzen"
+  * extension[asNeededFor][+]
+    * valueCodeableConcept.coding[0]
+      * system = $cs-sct
+      * version = "http://snomed.info/sct/11000274103/version/20251115"
+      * code = #50415004
+      * display = "Moderate Schmerzen"
+  * doseAndRate.doseQuantity
+    * value = 1
+    * unit = "Tablette"
+    * system = $cs-ucum
+    * code = #1

--- a/Resources/input/fsh/_Commons/aliases.fsh
+++ b/Resources/input/fsh/_Commons/aliases.fsh
@@ -117,6 +117,7 @@ Alias: $cs-v3-event-timing = http://terminology.hl7.org/CodeSystem/v3-TimingEven
 Alias: $vs-risk-probability = http://hl7.org/fhir/ValueSet/risk-probability
 Alias: $ext-data-absent-reason = http://hl7.org/fhir/StructureDefinition/data-absent-reason
 Alias: $ext-wirkstofftyp = http://fhir.de/StructureDefinition/WirkstofftypEX
+Alias: $ext-dosage-as-needed-for = http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor
 
 Alias: $appointmentStatus = http://hl7.org/fhir/appointmentstatus
 Alias: $cancelationReason = http://terminology.hl7.org/CodeSystem/appointment-cancellation-reason

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -7,6 +7,8 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 ## Version 
 
 Datum: tbd
+
+* `feature` Bedarfsmedikation mit mehreren Indikationen: R5-Backport-Extension `Dosage.asNeededFor` in `ISiKMedikationsVerordnung.dosageInstruction` ergänzt (ohne Must-Support; ab Stufe 6 mit Must-Support) und `asNeeded[x]` auf `boolean` eingeschränkt. Neue Use-Case-Seite `Bedarfsmedikation` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt
 * `documentation` Guidance zur Verwendung von List.mode (snapshot vs. working) in ISiKMedikationsListe anhand von Use-Cases ergänzt https://github.com/gematik/spec-ISiK-Basismodul/pull/1236
 * `fix` REQUIRED Suchparameter AllergyIntolerance.onset aus AMTS-Rolle entfernt aufgrund fehlerhafter Spezifikation https://github.com/gematik/spec-ISiK-Basismodul/pull/1212
 

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -9,6 +9,7 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 Datum: tbd
 
 * `feature` Bedarfsmedikation mit mehreren Indikationen: R5-Backport-Extension `Dosage.asNeededFor` in `ISiKMedikationsVerordnung.dosageInstruction` ergänzt (ohne Must-Support; ab Stufe 6 mit Must-Support) und `asNeeded[x]` auf `boolean` eingeschränkt. Neue Use-Case-Seite `Bedarfsmedikation` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt
+* `documentation` Neue Use-Case-Seite `Infusionen` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt
 * `documentation` Guidance zur Verwendung von List.mode (snapshot vs. working) in ISiKMedikationsListe anhand von Use-Cases ergänzt https://github.com/gematik/spec-ISiK-Basismodul/pull/1236
 * `fix` REQUIRED Suchparameter AllergyIntolerance.onset aus AMTS-Rolle entfernt aufgrund fehlerhafter Spezifikation https://github.com/gematik/spec-ISiK-Basismodul/pull/1212
 

--- a/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md
@@ -8,8 +8,8 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 Datum: tbd
 
-* `feature` Bedarfsmedikation mit mehreren Indikationen: R5-Backport-Extension `Dosage.asNeededFor` in `ISiKMedikationsVerordnung.dosageInstruction` ergänzt (ohne Must-Support; ab Stufe 6 mit Must-Support) und `asNeeded[x]` auf `boolean` eingeschränkt. Neue Use-Case-Seite `Bedarfsmedikation` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt
-* `documentation` Neue Use-Case-Seite `Infusionen` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt
+* `feature` Bedarfsmedikation mit mehreren Indikationen: R5-Backport-Extension `Dosage.asNeededFor` in `ISiKMedikationsVerordnung.dosageInstruction` ergänzt (ohne Must-Support; ab Stufe 6 mit Must-Support) und `asNeeded[x]` auf `boolean` eingeschränkt. Neue Use-Case-Seite `Bedarfsmedikation` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt https://github.com/gematik/spec-ISiK-Basismodul/pull/1264
+* `documentation` Neue Use-Case-Seite `Infusionen` mit Verweis auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) ergänzt https://github.com/gematik/spec-ISiK-Basismodul/pull/1264
 * `documentation` Guidance zur Verwendung von List.mode (snapshot vs. working) in ISiKMedikationsListe anhand von Use-Cases ergänzt https://github.com/gematik/spec-ISiK-Basismodul/pull/1236
 * `fix` REQUIRED Suchparameter AllergyIntolerance.onset aus AMTS-Rolle entfernt aufgrund fehlerhafter Spezifikation https://github.com/gematik/spec-ISiK-Basismodul/pull/1212
 

--- a/guides/Medikation-5/Einfuehrung/UseCases/Bedarfsmedikation.page.md
+++ b/guides/Medikation-5/Einfuehrung/UseCases/Bedarfsmedikation.page.md
@@ -1,0 +1,9 @@
+## Bedarfsmedikation
+
+Die Abbildung und fachliche Spezifikation von Bedarfsmedikation wird derzeit im Implementierungsleitfaden [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) erarbeitet. Die dort beschriebenen Konzepte und Festlegungen können als fachliche und technische Guidance für die Umsetzung von Bedarfsmedikation im Kontext dieses Implementierungsleitfadens herangezogen werden.
+
+ISiK-Medikation verwendet bereits die R5-Backport-Extension `Dosage.asNeededFor` zur Abbildung von Bedarfsindikationen. Dies entspricht der aktuellen fachlichen und technischen Ausrichtung des FHIR Medication IG Deutschland und stellt eine Vorabübernahme („Pre-Adaption“) dieser Festlegung dar, da die entsprechende Version des Implementierungsleitfadens zum Zeitpunkt der Veröffentlichung von ISiK noch nicht offiziell veröffentlicht war.
+
+Im Unterschied zu `asNeeded[x]` aus FHIR R4 ermöglicht die Extension:
+- die Angabe mehrerer Indikationen für eine Bedarfsmedikation,
+- die gleichzeitige Verwendung von `asNeededBoolean` und kodierten Indikationsangaben.

--- a/guides/Medikation-5/Einfuehrung/UseCases/Infusionen.page.md
+++ b/guides/Medikation-5/Einfuehrung/UseCases/Infusionen.page.md
@@ -1,0 +1,3 @@
+## Infusionen
+
+Die Abbildung und fachliche Spezifikation von Infusionen wird derzeit im Implementierungsleitfaden [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) erarbeitet. Die dort beschriebenen Konzepte und Festlegungen können als fachliche und technische Guidance für die Umsetzung von Infusionen im Kontext dieses Implementierungsleitfadens herangezogen werden.

--- a/guides/Medikation-5/Einfuehrung/UseCases/toc.yaml
+++ b/guides/Medikation-5/Einfuehrung/UseCases/toc.yaml
@@ -4,6 +4,8 @@
   filename: UebersichtAnwendungsfaelle.page.md
 - name: Bedarfsmedikation
   filename: Bedarfsmedikation.page.md
+- name: Infusionen
+  filename: Infusionen.page.md
 - name: Informationsmodell
   filename: Informationsmodell.page.md
 - name: AMTS

--- a/guides/Medikation-5/Einfuehrung/UseCases/toc.yaml
+++ b/guides/Medikation-5/Einfuehrung/UseCases/toc.yaml
@@ -2,6 +2,8 @@
   filename: Index.page.md
 - name: Übersicht Anwendungsfälle (Use Cases)
   filename: UebersichtAnwendungsfaelle.page.md
+- name: Bedarfsmedikation
+  filename: Bedarfsmedikation.page.md
 - name: Informationsmodell
   filename: Informationsmodell.page.md
 - name: AMTS


### PR DESCRIPTION
# PTDATA-2250: Bedarfsmedikation (asNeeded) – Verweis auf Medication DE IG + `Dosage.asNeededFor`

  ## Kontext / Motivation
  Bedarfsmedikation wird über `asNeeded[x]` definiert. `asNeededCodeableConcept` hat die Kardinalität `0..1` – damit lassen sich **mehrere** bedingte Bedarfe (z. B. mittlere UND schwere Schmerzen) nicht kodieren.

  Analog zur Umsetzung in **Stufe 6** wird dieses Problem gelöst, indem die R5-Backport-Extension `Dosage.asNeededFor` genutzt wird und im IG auf den [FHIR Medication IG Deutschland](https://ig.fhir.de/igs/medication/) verwiesen wird.

  ## Änderungen

  ### Profil (`ISiKMedikationsVerordnung`)
  - **Neue Extension** `ExtensionDosageAsNeededFor.fsh` – R5-Backport-Extension `Dosage.asNeededFor` (URL `http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor`), identisch zu Stufe 6. *(Das Paket `hl7.fhir.uv.xver-r5.r4#0.1.0` liefert `asNeededFor` nur für DeviceRequest/NutritionOrder, nicht für den Datentyp `Dosage` – daher manuell definiert, wie in Stufe 6.)*
  - `dosageInstruction.asNeeded[x] only boolean` – Bedingungen werden über die Extension (mehrfach, ODER-verknüpft) statt über `asNeededCodeableConcept` (0..1) abgebildet.
  - `dosageInstruction.extension[asNeededFor] 0..*` ergänzt – **bewusst ohne Must-Support**; per `^comment` mit Hinweis, dass das Element **ab Stufe 6 mit Must-Support** versehen ist.
  - Invariante `isik-dosage-as-needed-for`: wenn `asNeededFor` gesetzt ist, muss `asNeededBoolean = true` sein.
  - Neues Beispiel `ExampleISiKMedikationsVerordnungBedarfsmedikation` mit zwei Indikationen (Starke + Moderate Schmerzen, SNOMED CT).
  - Alias `$ext-dosage-as-needed-for` in `_Commons/aliases.fsh`.

  ### Dokumentation (IG-Seiten, analog Stufe 6)
  - Neue Use-Case-Seite **Bedarfsmedikation** mit Verweis auf den Medication DE IG und Erläuterung der `Dosage.asNeededFor`-Nutzung.
  - Neue Use-Case-Seite **Infusionen** mit Verweis auf den Medication DE IG.
  - Beide Seiten in `UseCases/toc.yaml` registriert (Reihenfolge: Übersicht → Bedarfsmedikation → Infusionen → Informationsmodell).
  - ReleaseNotes ergänzt.

  ## Geänderte Dateien
  - `Resources/input/fsh/Medikation/ExtensionDosageAsNeededFor.fsh` *(neu)*
  - `Resources/input/fsh/Medikation/ISiKMedikationsVerordnung.fsh`
  - `Resources/input/fsh/_Commons/aliases.fsh`
  - `guides/Medikation-5/Einfuehrung/UseCases/Bedarfsmedikation.page.md` *(neu)*
  - `guides/Medikation-5/Einfuehrung/UseCases/Infusionen.page.md` *(neu)*
  - `guides/Medikation-5/Einfuehrung/UseCases/toc.yaml`
  - `guides/Medikation-5/Einfuehrung/ReleaseNotes.page.md`

  ## Hinweise für Reviewer
  - **Must-Support:** Die `asNeededFor`-Extension ist in Stufe 5 abweichend zu Stufe 6 **ohne MS** (mit dokumentiertem Hinweis auf die MS-Pflicht ab Stufe 6). Das pre-existente `asNeededBoolean MS` bleibt unverändert.
  - **Generierte Artefakte:** Es sind nur die FSH-/Doku-Quellen enthalten. Die `fsh-generated`-Artefakte werden – wie im Repo üblich – per CI regeneriert und committet.

  ## Test / Validierung
  - `SUSHI v3.19.0`: **0 Errors, 0 Warnings** (Extensions 14 → 15, neues Beispiel exportiert).

  ## Akzeptanzkriterien
  - [x] Analog zu Stufe 6 sind Seiten in den IG integriert, die auf den Medication DE IG verweisen (Bedarfsmedikation, Infusionen).
  - [x] Mehrere bedingte Bedarfe sind über `Dosage.asNeededFor` kodierbar.