### PR TITLE
Stufe-6/basis/fix/ptdata-2278-allergy-valuesets

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "min": 1,
         "mustSupport": true
       },
@@ -502,6 +502,7 @@
         "id": "AllergyIntolerance.reaction.manifestation",
         "path": "AllergyIntolerance.reaction.manifestation",
         "short": "Manifestation der Reaktion",
+        "comment": "**Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -95,7 +95,8 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^comment = "**Begründung MS:** Die Kritikalität beschreibt das erwartete Risiko bei erneuter Exposition und dient der Priorisierung von Warnhinweisen."
 * code 1.. MS
   * ^short = "Benennung der Allergie/Unverträglichkeit"
-  * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen."
+  * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.
+  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
   * coding MS
     * ^slicing.discriminator.type = #pattern
     * ^slicing.discriminator.path = "system"
@@ -171,6 +172,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^comment = "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen."
   * manifestation MS
     * ^short = "Manifestation der Reaktion"
+    * ^comment = "**Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
     * coding MS
       * ^slicing.discriminator.type = #pattern
       * ^slicing.discriminator.path = "system"

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -96,6 +96,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
 * code 1.. MS
   * ^short = "Benennung der Allergie/Unverträglichkeit"
   * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.
+
   **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
   * coding MS
     * ^slicing.discriminator.type = #pattern

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -173,7 +173,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^comment = "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen."
   * manifestation MS
     * ^short = "Manifestation der Reaktion"
-    * ^comment = "**Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
+    * ^comment = "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
     * coding MS
       * ^slicing.discriminator.type = #pattern
       * ^slicing.discriminator.path = "system"

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -97,7 +97,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^short = "Benennung der Allergie/Unverträglichkeit"
   * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.
 
-  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
+  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
   * coding MS
     * ^slicing.discriminator.type = #pattern
     * ^slicing.discriminator.path = "system"

--- a/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "min": 1,
         "mustSupport": true
       },
@@ -502,6 +502,7 @@
         "id": "AllergyIntolerance.reaction.manifestation",
         "path": "AllergyIntolerance.reaction.manifestation",
         "short": "Manifestation der Reaktion",
+        "comment": "**Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "mustSupport": true
       },
       {

--- a/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "min": 1,
         "mustSupport": true
       },

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -13,7 +13,7 @@ Tags werden folgendermaßen verwendet:
 Datum: tbd
 
 * `fix` Fix der Invarianten `ISiK-enc-1` und `ISiK-enc-2` des Profils `ISiKKontaktGesundheitseinrichtung` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1260>
-* `improve` Hinzufügen von Hinweis zu späterer Adaption der durch die mio42 GmbH und das BfArM definierten Allergie ValueSets <https://github.com/gematik/spec-ISiK-Basismodul/pull/1268>
+* `improve` Hinzufügen von Anforderung zu den von mio42 GmbH und BfArM definierten Allergie ValueSets <https://github.com/gematik/spec-ISiK-Basismodul/pull/1268>
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -13,6 +13,7 @@ Tags werden folgendermaßen verwendet:
 Datum: tbd
 
 * `fix` Fix der Invarianten `ISiK-enc-1` und `ISiK-enc-2` des Profils `ISiKKontaktGesundheitseinrichtung` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1260>
+* `improve` Hinzufügen von Hinweis zu späterer Adaption der durch die mio42 GmbH und das BfArM definierten Allergie ValueSets <https://github.com/gematik/spec-ISiK-Basismodul/pull/1268>
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "min": 1,
         "mustSupport": true
       },
@@ -502,6 +502,7 @@
         "id": "AllergyIntolerance.reaction.manifestation",
         "path": "AllergyIntolerance.reaction.manifestation",
         "short": "Manifestation der Reaktion",
+        "comment": "**Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "mustSupport": true
       },
       {

--- a/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht bereit und wird daher zu einem späteren Zeitpunkt ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
         "min": 1,
         "mustSupport": true
       },


### PR DESCRIPTION
This pull request adds important clarifications and future guidance to the `ISiKAllergieUnvertraeglichkeit.fsh` resource. Specifically, it provides information about upcoming ValueSets for both the triggering substance and allergy manifestations, including references to where more information can be found.

**Documentation improvements:**

* Added a note to the `code` element's comment explaining that a ValueSet for the triggering substance (`auslösende Substanz`) is being developed by mio42 GmbH and BfArM, with a link for further information. This ValueSet will be added in the future once available.
* Added a similar note to the `manifestation` element's comment regarding a forthcoming ValueSet for allergy manifestations, also developed by mio42 GmbH and BfArM, with a reference link.