### PR TITLE
stufe-6/icu/fix/change-role-allocation-ptdata-2283

### DIFF
--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedRolle.json
@@ -51,6 +51,7 @@
             }
           ],
           "supportedProfile": [
+            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-pulmonalarterieller-wedge-druck",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-preduktal-durch-pulsoxymetrie",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-postduktal-durch-pulsoxymetrie",
@@ -95,6 +96,14 @@
             "https://gematik.de/fhir/isik/StructureDefinition/mii-pr-icu-vent-spontanes-atemzugvolumen"
           ],
           "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
             {
               "extension": [
                 {

--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedRolle.json
@@ -51,7 +51,6 @@
             }
           ],
           "supportedProfile": [
-            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-pulmonalarterieller-wedge-druck",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-preduktal-durch-pulsoxymetrie",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-postduktal-durch-pulsoxymetrie",
@@ -96,14 +95,6 @@
             "https://gematik.de/fhir/isik/StructureDefinition/mii-pr-icu-vent-spontanes-atemzugvolumen"
           ],
           "_supportedProfile": [
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
-                }
-              ]
-            },
             {
               "extension": [
                 {

--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceMinimalRolle.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceMinimalRolle.json
@@ -51,7 +51,6 @@
             }
           ],
           "supportedProfile": [
-            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergewicht-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergroesse-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-ideales-koerpergewicht",
@@ -88,14 +87,6 @@
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerperkerntemperatur-stirn"
           ],
           "_supportedProfile": [
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
-                }
-              ]
-            },
             {
               "extension": [
                 {

--- a/Resources/input/fsh/ICU/Rollen/ISiK-CapabilityStatementVitalSignICUSourceExtendedRolle.fsh
+++ b/Resources/input/fsh/ICU/Rollen/ISiK-CapabilityStatementVitalSignICUSourceExtendedRolle.fsh
@@ -29,6 +29,7 @@ Die Interaktionen umfassen die Bereitstellung von Vitalparametern, die für die 
     * insert CapabilityStatementExpectationExt(SHALL)
 
     // MII-ICU backport profiles extended (e.g for PDMS)
+    * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Intrakranieller_Druck_Icp, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Pulmonalarterieller_Wedge_Druck, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Sauerstoffsaettigung_Im_Blut_Preduktal_Durch_Pulsoxymetrie, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Sauerstoffsaettigung_Im_Blut_Postduktal_Durch_Pulsoxymetrie, SHALL)

--- a/Resources/input/fsh/ICU/Rollen/ISiK-CapabilityStatementVitalSignICUSourceExtendedRolle.fsh
+++ b/Resources/input/fsh/ICU/Rollen/ISiK-CapabilityStatementVitalSignICUSourceExtendedRolle.fsh
@@ -29,7 +29,7 @@ Die Interaktionen umfassen die Bereitstellung von Vitalparametern, die für die 
     * insert CapabilityStatementExpectationExt(SHALL)
 
     // MII-ICU backport profiles extended (e.g for PDMS)
-    * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Intrakranieller_Druck_Icp, SHALL)
+    
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Pulmonalarterieller_Wedge_Druck, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Sauerstoffsaettigung_Im_Blut_Preduktal_Durch_Pulsoxymetrie, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Sauerstoffsaettigung_Im_Blut_Postduktal_Durch_Pulsoxymetrie, SHALL)
@@ -63,7 +63,7 @@ Die Interaktionen umfassen die Bereitstellung von Vitalparametern, die für die 
 
     // Paraemter aus dem Use Case Organspendeerkennung, die auch für den ICU-Normalstation-Workflow relevant sind
     // MII
-    * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Intrakranieller_Druck_Icp, SHALL)
+    * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Intrakranieller_Druck_Icp, SHALL) 
     * insert SupportedProfileCapExpectationExt(MII_PR_ICU_MUV_zerebraler_Perfusionsdruck, SHALL)
     * insert SupportedProfileCapExpectationExt(MII_PR_ICU_Untersuchung_Pupillenlichtreaktion_Indirekt, SHALL)
     * insert SupportedProfileCapExpectationExt(MII_PR_ICU_Untersuchung_Pupillenform, SHALL)

--- a/Resources/input/fsh/ICU/Rollen/ISiK-CapabilityStatementVitalSignICUSourceMinimalRolle.fsh
+++ b/Resources/input/fsh/ICU/Rollen/ISiK-CapabilityStatementVitalSignICUSourceMinimalRolle.fsh
@@ -34,7 +34,7 @@ Die Interaktionen umfassen die Bereitstellung von Vitalparametern, die für die 
     * insert CapabilityStatementExpectationExt(SHALL)
 
     // MII-ICU backport profiles for kis
-    * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Intrakranieller_Druck_Icp, SHALL)
+
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Koerpergewicht_Percentil_Altersabhaengig, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Koerpergroesse_Percentil_Altersabhaengig, SHALL)
     * insert SupportedProfileCapExpectationExt(SD_MII_ICU_Ideales_Koerpergewicht, SHALL)

--- a/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
@@ -3,6 +3,12 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 * Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
 
+### Version 6.0.0
+
+Datum: tbd
+
+* `fix` Verschieben des Profils `SD_MII_ICU_Intrakranieller_Druck_Icp` aus der ICUSourceMinimalRolle in die `ICUSourceExtendedRolle` 
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
@@ -7,7 +7,7 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Datum: tbd
 
-* `fix` Verschieben des Profils `SD_MII_ICU_Intrakranieller_Druck_Icp` aus der ICUSourceMinimalRolle in die `ICUSourceExtendedRolle` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1269>
+* `fix` Verschieben des Profils `SD_MII_ICU_Intrakranieller_Druck_Icp` aus der ICUSourceMinimalRolle in die `ICUSourceExtendedRolle` und damit Lockerung der Anforderungen an Systeme <https://github.com/gematik/spec-ISiK-Basismodul/pull/1269>
 * `fix` Hinzufügen eines Codes zu den ValueSets `VS_MII_ICU_Code_Monitoring_und_Vitaldaten_SNOMED` und `VS_MII_ICU_Code_Monitoring_und_Vitaldaten_LOINC` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1253>
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)

--- a/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
@@ -7,7 +7,7 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Datum: tbd
 
-* `fix` Verschieben des Profils `SD_MII_ICU_Intrakranieller_Druck_Icp` aus der ICUSourceMinimalRolle in die `ICUSourceExtendedRolle` und damit Lockerung der Anforderungen an Systeme <https://github.com/gematik/spec-ISiK-Basismodul/pull/1269>
+* `fix` Profil `SD_MII_ICU_Intrakranieller_Druck_Icp` ist nicht mehr Bestandteil der `ICUSourceMinimalRolle` und bleibt nur noch in der `ICUSourceExtendedRolle` verpflichtend (Lockerung der Anforderungen an Systeme) <https://github.com/gematik/spec-ISiK-Basismodul/pull/1269>
 * `fix` Hinzufügen eines Codes zu den ValueSets `VS_MII_ICU_Code_Monitoring_und_Vitaldaten_SNOMED` und `VS_MII_ICU_Code_Monitoring_und_Vitaldaten_LOINC` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1253>
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)

--- a/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
@@ -7,7 +7,7 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Datum: tbd
 
-* `fix` Verschieben des Profils `SD_MII_ICU_Intrakranieller_Druck_Icp` aus der ICUSourceMinimalRolle in die `ICUSourceExtendedRolle` 
+* `fix` Verschieben des Profils `SD_MII_ICU_Intrakranieller_Druck_Icp` aus der ICUSourceMinimalRolle in die `ICUSourceExtendedRolle` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1269>
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedAkteur-expanded.json
+++ b/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedAkteur-expanded.json
@@ -440,7 +440,6 @@
             }
           ],
           "supportedProfile": [
-            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergewicht-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergroesse-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-ideales-koerpergewicht",
@@ -475,6 +474,7 @@
             "https://gematik.de/fhir/isik/StructureDefinition/mii-pr-icu-bilanz-einfuhr-spendermilch",
             "https://gematik.de/fhir/isik/StructureDefinition/mii-pr-icu-bilanz-tagesbilanz-fluessigkeit",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerperkerntemperatur-stirn",
+            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-pulmonalarterieller-wedge-druck",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-preduktal-durch-pulsoxymetrie",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-postduktal-durch-pulsoxymetrie",

--- a/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedRolle.json
+++ b/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceExtendedRolle.json
@@ -51,6 +51,7 @@
             }
           ],
           "supportedProfile": [
+            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-pulmonalarterieller-wedge-druck",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-preduktal-durch-pulsoxymetrie",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-o2saettigung-im-blut-postduktal-durch-pulsoxymetrie",
@@ -95,6 +96,14 @@
             "https://gematik.de/fhir/isik/StructureDefinition/mii-pr-icu-vent-spontanes-atemzugvolumen"
           ],
           "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
             {
               "extension": [
                 {

--- a/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceMinimalAkteur-expanded.json
+++ b/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceMinimalAkteur-expanded.json
@@ -440,7 +440,6 @@
             }
           ],
           "supportedProfile": [
-            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergewicht-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergroesse-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-ideales-koerpergewicht",
@@ -497,14 +496,6 @@
             "https://gematik.de/fhir/isik/StructureDefinition/ISiKEKG"
           ],
           "_supportedProfile": [
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
-                }
-              ]
-            },
             {
               "extension": [
                 {

--- a/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceMinimalRolle.json
+++ b/publisher-guides/ICU/input/resources/CapabilityStatement-ISiKCapabilityStatementVitalSignICUSourceMinimalRolle.json
@@ -51,7 +51,6 @@
             }
           ],
           "supportedProfile": [
-            "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-intrakranieller-druck-icp",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergewicht-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerpergroesse-percentil-altersabhaengig",
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-ideales-koerpergewicht",
@@ -88,14 +87,6 @@
             "https://gematik.de/fhir/isik/StructureDefinition/sd-mii-icu-koerperkerntemperatur-stirn"
           ],
           "_supportedProfile": [
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
-                }
-              ]
-            },
             {
               "extension": [
                 {


### PR DESCRIPTION
This pull request updates the assignment of the `SD_MII_ICU_Intrakranieller_Druck_Icp` profile between ICU source roles and documents the change in the release notes. The main purpose is to move this profile from the minimal role to the extended role, reflecting a change in requirements for profile support.

Profile assignment changes:

* Moved the `SD_MII_ICU_Intrakranieller_Druck_Icp` profile from `ISiK-CapabilityStatementVitalSignICUSourceMinimalRolle.fsh` (Minimal Role) to `ISiK-CapabilityStatementVitalSignICUSourceExtendedRolle.fsh` (Extended Role), so it is now only required for the extended role. [[1]](diffhunk://#diff-8e00bc2370b6a11dbf477b04225ea27575fe11eadc92037955a7a289f64eb04aL37-R37) [[2]](diffhunk://#diff-a4f6042ee13823761b8a05f2092e8a92d2270fe4192ce240b85e972eda1fd6fdR32)

Documentation updates:

* Added a new entry in the release notes (`ReleaseNotes.md`) under version 6.0.0 to document the profile movement from the minimal to the extended role.