### PR TITLE
Stufe-6/all/add-sentence-to-releasenotes-ptdata-2075

### DIFF
--- a/publisher-guides/AMTS/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/AMTS/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,11 @@
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -14,6 +14,8 @@ Datum: tbd
 
 * `fix` Fix der Invarianten `ISiK-enc-1` und `ISiK-enc-2` des Profils `ISiKKontaktGesundheitseinrichtung` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1260>
 
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Connect/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Connect/input/pagecontent/ReleaseNotes.md
@@ -1,6 +1,12 @@
 
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Dokumentenaustausch/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Dokumentenaustausch/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,11 @@
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Formular/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Formular/input/pagecontent/ReleaseNotes.md
@@ -3,6 +3,7 @@
 Datum: tbd
 
 Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+**Hinweis:** Dies ändert nichts daran, dass das Formularmodul in Stufe 6 als Ganzes nicht normativ bindend ist.
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/Formular/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Formular/input/pagecontent/ReleaseNotes.md
@@ -1,3 +1,9 @@
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/ICU/input/pagecontent/ReleaseNotes.md
@@ -9,6 +9,8 @@ Datum: tbd
 
 * `fix` Hinzufügen eines Codes zu den ValueSets `VS_MII_ICU_Code_Monitoring_und_Vitaldaten_SNOMED` und `VS_MII_ICU_Code_Monitoring_und_Vitaldaten_LOINC` <https://github.com/gematik/spec-ISiK-Basismodul/pull/1253>
 
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Labor/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Labor/input/pagecontent/ReleaseNotes.md
@@ -7,6 +7,8 @@ Datum: tbd.
 
 * `improve` QA-Verbesserungen: IG-Publisher-Parameter hinzugefügt, ignoreWarnings.txt eingeführt, Umstellung auf deutsche Display-Validierung <https://github.com/gematik/spec-ISiK-Basismodul/pull/1190>
 
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Medikation/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,11 @@
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Organspendeerkennung/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Organspendeerkennung/input/pagecontent/ReleaseNotes.md
@@ -1,6 +1,10 @@
-### Release Notes
-
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
+
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/Subscription/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Subscription/input/pagecontent/ReleaseNotes.md
@@ -5,6 +5,7 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 Datum: tbd
 
 Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+**Hinweis:** Dies ändert nichts daran, dass das Subscription-Moul in Stufe 6 als Ganzes nicht normativ bindend ist.
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/Subscription/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Subscription/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,11 @@
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026

--- a/publisher-guides/Terminplanung/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Terminplanung/input/pagecontent/ReleaseNotes.md
@@ -1,11 +1,13 @@
 
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
-### Version t.b.d
+### Version 6.0.0
 
 Datum: t.b.d
 
-* Ungenutztes Profil `ISiKTerminKontaktMitGesundheitseinrichtung` entfernt in https://github.com/gematik/spec-ISiK-Basismodul/pull/1262
+* Ungenutztes Profil `ISiKTerminKontaktMitGesundheitseinrichtung` entfernt in <https://github.com/gematik/spec-ISiK-Basismodul/pull/1262>
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
 
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 

--- a/publisher-guides/Vitalparameter/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Vitalparameter/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,11 @@
 ﻿Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+### Version 6.0.0
+
+Datum: tbd
+
+Mit Inkrafttreten der Stufe 6 werden auch sämtliche nachfolgend aufgeführten Änderungen verbindlich.
+
 ### Version 6.0.0-rc1 (Benehmensherstellung)
 
 Datum: 10.06.2026


### PR DESCRIPTION
This pull request updates the release notes across all ISiK publisher guides to introduce a new section for Version 6.0.0. The main change is the addition of a placeholder for Version 6.0.0 with the date marked as "tbd" and a statement clarifying that all subsequent listed changes will become binding with the activation of Stage 6. This ensures consistency and prepares each module's documentation for the upcoming major release.

Release notes updates for Version 6.0.0:

* Added a new section `### Version 6.0.0` with a placeholder date and a statement that all listed changes become binding with Stage 6 in the release notes of the following modules: `AMTS`, `Connect`, `Dokumentenaustausch`, `Formular`, `Medikation`, `Organspendeerkennung`, `Subscription`, and `Vitalparameter`. [[1]](diffhunk://#diff-891f7a2f96970b34ee6b83f1a213906ddf9e18748e890095ee7dd70f71ca7af5R3-R8) [[2]](diffhunk://#diff-31f79a368d7fca902f936b9b359a8ebd176129e924fb92ca878eb93c044b4144R4-R9) [[3]](diffhunk://#diff-eb7b21f7fc980b81bd2b495ac282e4ec9cc6a6274dcbc592e71ddf20b67b5978R3-R8) [[4]](diffhunk://#diff-4a9c6fe755242a4d69148e494ed7915ead2784d00c9fbf5eadd48e2c9ea92abbR1-R6) [[5]](diffhunk://#diff-8e32a4cfcbe34f47183d660e61b767130700ddba888f03004549aae4d4417488R3-R8) [[6]](diffhunk://#diff-d63c4298e55ebe1319fe47124438d1aee50375262313892c9acb1e9fb158b23aL1-R8) [[7]](diffhunk://#diff-1cff0b5f161a44c4531d9439971fb8629bea92e8d87e582c961b5aaf40ab8c54R3-R8) [[8]](diffhunk://#diff-a85569c751cbc9c3973e9e27bfb43e36899d75e1f46dddacf201ed470bcbe7b9R3-R8)
* In the `Basis`, `ICU`, and `Labor` modules, added the same binding statement for Stage 6 after the most recent change entries. [[1]](diffhunk://#diff-4929ca28ca791dc814650e9f15d46f69eeb62da1e00ada58b0ae0585ab1f75adR17-R18) [[2]](diffhunk://#diff-332e8e3696cd0981c41351413e0da15b032a082851a4d73d668cef24c40d5387R12-R13) [[3]](diffhunk://#diff-905e1fd65c9b07a2b7fa4a4d960874295db0062cbeb97ae840fb1e9eda93f2caR10-R11)
* In `Terminplanung`, updated the version section from a placeholder to `6.0.0`, added the binding statement, and formatted the release notes for clarity.