### PR TITLE
fix: update JAVA_VALIDATOR_VERSION for tx validation workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,8 @@ jobs:
             -advisor-file validator/advisor.json
             -resolution-context file:Resources/fsh-generated/resources/
             -sct 11000274103/version/20251115
+#          FIXME: remove after new version of firely-terminal-pipeline is released. Workaround for hanging tx validation.
+          JAVA_VALIDATOR_VERSION: 6.9.11
           SIMPLIFIER_USERNAME: ${{ secrets.SIMPLIFIER_USERNAME }}
           SIMPLIFIER_PASSWORD: ${{ secrets.SIMPLIFIER_PASSWORD }}
           SUSHI_ENABLED: true


### PR DESCRIPTION
This pull request introduces a temporary workaround for a known issue with the tx validation step in the pipeline. Specifically, it sets the `JAVA_VALIDATOR_VERSION` environment variable to a fixed version to prevent the validation from hanging. This change is intended to be removed once a new version of the `firely-terminal-pipeline` is released.

Workaround for validation issue:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R70-R71): Added `JAVA_VALIDATOR_VERSION: 6.9.11` as a temporary fix for a hanging tx validation step.