### PR TITLE
fix: add validation comments for medication resources in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,14 @@ jobs:
             ValueSet-mii-vs-icu-score-rass.json|VALUESET_INCLUDE_INVALID_CONCEPT_CODE|*Unknown code 'LA33966-5'*|ValueSet.compose.include[0].concept[8]
             ValueSet-mii-vs-icu-score-rass.json|VALUESET_INCLUDE_INVALID_CONCEPT_CODE|*Unknown code 'LA33967-3'*|ValueSet.compose.include[0].concept[9]
             Observation-ExampleOrganRASS20200311.json|Terminology_TX_NoValid_1_CC|*MII VS ICU Score RASS*|Observation.value.ofType(CodeableConcept)
+            # Validation for https://hl7.org/fhir/uv/ips/STU2/ValueSet-medicine-route-of-administration.html currently fails because the .ch tx server fails during validation.
+            # zulip thread: https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/https.3A.2F.2Ftx.2Efhir.2Ech.2Fr4.20responsible.20IPS.20VS.3F/with/607452517
+            Medication-ExampleISiKMedikament2.json|Validation_VAL_Profile_NotSlice||Medication.form.coding[0]
+            Medication-ExampleISiKMedikament8.json|Validation_VAL_Profile_NotSlice||Medication.form.coding[0]
+            Medication-ExampleISiKMedikament9.json|Validation_VAL_Profile_NotSlice||Medication.form.coding[0]
+            Medication-ParacetamolInfusion.json|Validation_VAL_Profile_NotSlice||Medication.form.coding[0]
+            MedicationAdministration-ExampleISiKMedikationsVerabreichung3.json|Terminology_TX_NoValid_12||MedicationAdministration.dosage.route.coding[0]
+            MedicationAdministration-ExampleISiKMedikationsVerabreichung4.json|Terminology_TX_NoValid_12||MedicationAdministration.dosage.route.coding[0]
 
       - name: Validate Resource Status
         uses: patrick-werner/fhir-resource-status-check@1.2.1


### PR DESCRIPTION
This pull request updates the `.github/workflows/main.yml` file to add comments and suppressions for known validation issues related to FHIR medication route of administration, which currently fail due to external terminology server problems. This helps keep the workflow green while these upstream issues are unresolved.

Validation suppressions and documentation:

* Added comments explaining that validation failures for the medication route of administration ValueSet are due to issues with the external `.ch` terminology server, including a link to the relevant Zulip discussion thread.
* Suppressed validation errors for several `Medication` and `MedicationAdministration` example resources by listing them in the workflow configuration, preventing these known issues from causing CI failures.