### PR TITLE
Stufe 5 - Improve practiceSetting cardinality and binding

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -589,11 +589,10 @@
       {
         "id": "DocumentReference.context.practiceSetting",
         "path": "DocumentReference.context.practiceSetting",
-        "comment": "Binding auf IHE-DE Terminologie hinzugefügt",
-        "min": 1,
+        "comment": "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen.",
         "mustSupport": true,
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode"
         },
         "mapping": [

--- a/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
@@ -232,9 +232,10 @@ Ab dieser Stufe ist für die menschenlesbare Bezeichnung des Dokuments das Eleme
   * facilityType from http://ihe-d.de/ValueSets/IHEXDShealthcareFacilityTypeCode (required)
     * ^short = "Art der Einrichtung, aus der das Dokument stammt"
     * ^comment = "Kann, sofern keine abweichende Information bekannt ist auf &quot;KHS&quot; gesetzt werden."
-  * practiceSetting 1.. MS
-  * practiceSetting from http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode (required)
-    * ^comment = "Binding auf IHE-DE Terminologie hinzugefügt"
+  * practiceSetting MS
+    * ^comment = "Must Support Begründung: Der organisatorische Kontext, aus dem das Dokument entstanden ist, stellt eine wesentliche Information zur Einordnung des Dokuments dar. Dennoch kann insbeosndere in Fällen, in denen Dokumente von außerklinischen Personen (z. B. Patienten und Angehörigen) übergeben werden, eine solche Angabe nicht zwingend gefordert werden (daher keine Kardinalität 1..)."
+  * practiceSetting from http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode (extensible)
+    * ^comment = "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen."
 
 
 

--- a/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
@@ -233,7 +233,7 @@ Ab dieser Stufe ist für die menschenlesbare Bezeichnung des Dokuments das Eleme
     * ^short = "Art der Einrichtung, aus der das Dokument stammt"
     * ^comment = "Kann, sofern keine abweichende Information bekannt ist auf &quot;KHS&quot; gesetzt werden."
   * practiceSetting MS
-    * ^comment = "Must Support Begründung: Der organisatorische Kontext, aus dem das Dokument entstanden ist, stellt eine wesentliche Information zur Einordnung des Dokuments dar. Dennoch kann insbeosndere in Fällen, in denen Dokumente von außerklinischen Personen (z. B. Patienten und Angehörigen) übergeben werden, eine solche Angabe nicht zwingend gefordert werden (daher keine Kardinalität 1..)."
+    * ^comment = "Must Support Begründung: Der organisatorische Kontext, aus dem das Dokument entstanden ist, stellt eine wesentliche Information zur Einordnung des Dokuments dar. Dennoch kann insbesondere in Fällen, in denen Dokumente von außerklinischen Personen (z. B. Patienten und Angehörigen) übergeben werden, eine solche Angabe nicht zwingend gefordert werden (daher keine Kardinalität 1..)."
   * practiceSetting from http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode (extensible)
     * ^comment = "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen."
 

--- a/guides/Dokumentenaustausch-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Dokumentenaustausch-5/Einfuehrung/ReleaseNotes.page.md
@@ -9,6 +9,13 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 Offene Punkte und bekannte Probleme siehe [GitHub Issues](https://github.com/gematik/ISiK-Dokumentenaustausch/issues?q=is%3Aissue+is%3Aopen+label%3A%22offene+Punkte+Ballot%22)
 
+## Version 5.x.x
+
+Datum: tbd.
+
+* `improve` Für DocumentReference.context.practiceSetting wurde die Kardinalität 1.. entfernt und das required binding auf extensible gelockert
+
+
 ## Version 5.1.3
 
 Datum: 17.07.2026

--- a/guides/Dokumentenaustausch-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Dokumentenaustausch-5/Einfuehrung/ReleaseNotes.page.md
@@ -13,7 +13,7 @@ Offene Punkte und bekannte Probleme siehe [GitHub Issues](https://github.com/gem
 
 Datum: tbd.
 
-* `improve` Für DocumentReference.context.practiceSetting wurde die Kardinalität 1.. entfernt und das required binding auf extensible gelockert
+* `improve` Für DocumentReference.context.practiceSetting wurde die Kardinalität 1.. entfernt und das required binding auf extensible gelockert https://github.com/gematik/spec-ISiK-Basismodul/pull/1309
 
 
 ## Version 5.1.3


### PR DESCRIPTION
Adjust the cardinality of `practiceSetting` to remove the requirement and change the binding to extensible, allowing for greater flexibility in coding. This change reflects the need for contextual information while accommodating cases where such information may not be mandatory.

