### PR TITLE
Main stufe 6 - improve practiceSetting PTDATA 2287

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -610,11 +610,10 @@
       {
         "id": "DocumentReference.context.practiceSetting",
         "path": "DocumentReference.context.practiceSetting",
-        "comment": "Binding auf IHE-DE Terminologie hinzugefügt",
-        "min": 1,
+        "comment": "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen.",
         "mustSupport": true,
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode"
         },
         "mapping": [

--- a/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
@@ -242,9 +242,10 @@ Ab dieser Stufe ist für die menschenlesbare Bezeichnung des Dokuments das Eleme
   * facilityType from http://ihe-d.de/ValueSets/IHEXDShealthcareFacilityTypeCode (required)
     * ^short = "Art der Einrichtung, aus der das Dokument stammt"
     * ^comment = "Kann, sofern keine abweichende Information bekannt ist auf &quot;KHS&quot; gesetzt werden."
-  * practiceSetting 1.. MS
-  * practiceSetting from http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode (required)
-    * ^comment = "Binding auf IHE-DE Terminologie hinzugefügt"
+  * practiceSetting MS
+    * ^comment = "Must Support Begründung: Der organisatorische Kontext, aus dem das Dokument entstanden ist, stellt eine wesentliche Information zur Einordnung des Dokuments dar. Dennoch kann insbeosndere in Fällen, in denen Dokumente von außerklinischen Personen (z. B. Patienten und Angehörigen) übergeben werden, eine solche Angabe nicht zwingend gefordert werden (daher keine Kardinalität 1..)."
+  * practiceSetting from http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode (extensible)
+    * ^comment = "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen."
 
 
 

--- a/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
+++ b/Resources/input/fsh/Dokumentenaustausch/ISiKDokumentenMetadaten.fsh
@@ -243,7 +243,7 @@ Ab dieser Stufe ist für die menschenlesbare Bezeichnung des Dokuments das Eleme
     * ^short = "Art der Einrichtung, aus der das Dokument stammt"
     * ^comment = "Kann, sofern keine abweichende Information bekannt ist auf &quot;KHS&quot; gesetzt werden."
   * practiceSetting MS
-    * ^comment = "Must Support Begründung: Der organisatorische Kontext, aus dem das Dokument entstanden ist, stellt eine wesentliche Information zur Einordnung des Dokuments dar. Dennoch kann insbeosndere in Fällen, in denen Dokumente von außerklinischen Personen (z. B. Patienten und Angehörigen) übergeben werden, eine solche Angabe nicht zwingend gefordert werden (daher keine Kardinalität 1..)."
+    * ^comment = "Must Support Begründung: Der organisatorische Kontext, aus dem das Dokument entstanden ist, stellt eine wesentliche Information zur Einordnung des Dokuments dar. Dennoch kann insbesondere in Fällen, in denen Dokumente von außerklinischen Personen (z. B. Patienten und Angehörigen) übergeben werden, eine solche Angabe nicht zwingend gefordert werden (daher keine Kardinalität 1..)."
   * practiceSetting from http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode (extensible)
     * ^comment = "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen."
 

--- a/publisher-guides/Dokumentenaustausch/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Dokumentenaustausch/input/pagecontent/ReleaseNotes.md
@@ -1,5 +1,12 @@
 Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://semver.org/lang/de/) verwendet.
 
+
+### Version 6.X.Y.
+
+Datum: tbd.
+
+* `improve` Für DocumentReference.context.practiceSetting wurde die Kardinalität 1.. entfernt und das required binding auf extensible gelockert https://github.com/gematik/spec-ISiK-Basismodul/pull/1310
+
 ### Version 6.0.0
 
 Datum: 01.07.2026

--- a/publisher-guides/Dokumentenaustausch/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Dokumentenaustausch/input/pagecontent/ReleaseNotes.md
@@ -5,7 +5,7 @@ Im Rahmen der ISiK-Veröffentlichungen wird das [Semantic Versioning](https://se
 
 Datum: tbd.
 
-* `improve` Für DocumentReference.context.practiceSetting wurde die Kardinalität 1.. entfernt und das required binding auf extensible gelockert https://github.com/gematik/spec-ISiK-Basismodul/pull/1310
+* `improve` Für DocumentReference.context.practiceSetting wurde die Kardinalität 1.. entfernt und das required binding auf extensible gelockert <https://github.com/gematik/spec-ISiK-Basismodul/pull/1310>
 
 ### Version 6.0.0
 

--- a/publisher-guides/Dokumentenaustausch/input/resources/StructureDefinition-ISiKDokumentenMetadaten.json
+++ b/publisher-guides/Dokumentenaustausch/input/resources/StructureDefinition-ISiKDokumentenMetadaten.json
@@ -610,11 +610,10 @@
       {
         "id": "DocumentReference.context.practiceSetting",
         "path": "DocumentReference.context.practiceSetting",
-        "comment": "Binding auf IHE-DE Terminologie hinzugefügt",
-        "min": 1,
+        "comment": "Binding auf IHE-DE Terminologie hinzugefügt. Ein extensible Binding ermöglicht Flexibilität bei der Kodierung, da es sich bei der Implementierung nicht als praktikabel erwiesen hat, ausschließlich Codes aus dem gewählten ValueSet zuzulassen.",
         "mustSupport": true,
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode"
         },
         "mapping": [


### PR DESCRIPTION
Adjust the cardinality of `practiceSetting` to remove the requirement and change the binding to extensible, allowing for greater flexibility in coding. This change reflects the need for contextual information while accommodating cases where such information may not be mandatory.

