### PR TITLE
Stufe-6 - add VS and package dependency

### DIFF
--- a/.github/actions/run-sushi-with-zts/README.md
+++ b/.github/actions/run-sushi-with-zts/README.md
@@ -1,0 +1,50 @@
+# run-sushi-with-zts
+
+Composite action wrapping gematik's reference `sushi-wrap.sh`
+([gematik/zts-api-client-examples](https://github.com/gematik/zts-api-client-examples/tree/main/sushi-wrap))
+so FHIR packages only available via the BfArM Zentraler Terminologieserver
+(ZTS) — e.g. `kbv.all.terminology.allergyintolerance` — are downloaded into
+the local FHIR package cache before SUSHI runs.
+
+Used by `ig-publisher.yml` and `complieswith-export.yml` in place of a plain
+`sushi`/`npx fsh-sushi` invocation.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `dir` | yes | — | Directory containing the `sushi-config.yaml` to resolve dependencies for (SUSHI runs there) |
+| `accepted-download-conditions` | yes | — | Comma-separated list of accepted ZTS download conditions (see setup below) |
+| `sushi-command` | no | `sushi .` | Override for setups without a global `sushi` binary, e.g. `npx fsh-sushi . -s` |
+| `sushi-wrap-url` | no | current PTDATA-2340 fork branch | Raw URL of `sushi-wrap.sh` |
+
+## One-time setup: `ZTS_ACCEPTED_DOWNLOAD_CONDITIONS`
+
+The list of accepted ZTS download conditions is not hardcoded in the workflow —
+it must be configured as a repository (or organization) Actions **variable**:
+
+1. Go to **Settings → Secrets and variables → Actions → Variables** in the repository.
+2. Add a repository variable named `ZTS_ACCEPTED_DOWNLOAD_CONDITIONS`.
+3. Set its value to the comma-separated list of accepted download conditions, e.g.:
+   ```
+   kbv.all.terminology.allergyintolerance
+   ```
+   Add more entries (comma-separated) as additional ZTS-only packages become needed.
+4. Review the applicable download conditions on the [BfArM terminology website](https://terminologien.bfarm.de) before accepting them.
+
+Until this variable is created, editors/linters may flag
+`${{ vars.ZTS_ACCEPTED_DOWNLOAD_CONDITIONS }}` in the calling workflows with a
+"Context access might be invalid" warning — this is expected and harmless; it
+just means GitHub doesn't know about the variable yet.
+
+## Notes
+
+- `jq`, `yq` (mikefarah/yq), and `uuidgen` (needed internally by
+  `sushi-wrap.sh`) are installed automatically via `apt-get`/`apk` if not
+  already present; `sudo` is used automatically when not running as root
+  (e.g. plain GitHub-hosted runners, as opposed to the IG Publisher container).
+- `sushi-wrap-url` is pinned to the
+  [1.0.0](https://github.com/gematik/zts-api-client-examples/releases/tag/1.0.0)
+  release tag, which includes env-var overrides for
+  `ACCEPTED_DOWNLOAD_CONDITIONS`/`SUSHI_COMMAND` and a package-cache-dir bug
+  fix contributed upstream.

--- a/.github/actions/run-sushi-with-zts/action.yml
+++ b/.github/actions/run-sushi-with-zts/action.yml
@@ -1,0 +1,61 @@
+name: Run SUSHI with ZTS packages
+description: >
+  Downloads FHIR packages only available via the BfArM Zentraler
+  Terminologieserver (ZTS) into the local package cache using gematik's
+  sushi-wrap.sh, then runs SUSHI.
+
+inputs:
+  dir:
+    description: Directory containing the sushi-config.yaml to resolve dependencies for (SUSHI runs there)
+    required: true
+  accepted-download-conditions:
+    description: Comma-separated list of accepted ZTS download conditions
+    required: true
+  sushi-command:
+    description: Command used to invoke SUSHI (override for setups without a global "sushi" binary, e.g. "npx fsh-sushi . -s")
+    required: false
+    default: "sushi ."
+  sushi-wrap-url:
+    description: Raw URL of sushi-wrap.sh
+    required: false
+    default: https://raw.githubusercontent.com/gematik/zts-api-client-examples/refs/tags/1.0.0/sushi-wrap/BfArM-Package-Test/sushi-wrap.sh
+
+runs:
+  using: composite
+  steps:
+    # sushi-wrap.sh needs jq, yq (mikefarah/yq) and uuidgen (util-linux); none
+    # of these are guaranteed to be present on the calling job's environment.
+    - name: Install ZTS wrapper prerequisites
+      shell: bash
+      run: |
+        as_root() { if [ "$(id -u)" -eq 0 ]; then "$@"; else sudo "$@"; fi; }
+        if ! command -v jq >/dev/null 2>&1 || ! command -v uuidgen >/dev/null 2>&1; then
+          if command -v apt-get >/dev/null 2>&1; then
+            as_root apt-get update -qq && as_root apt-get install -y -qq jq uuid-runtime >/dev/null
+          elif command -v apk >/dev/null 2>&1; then
+            as_root apk add --no-cache jq util-linux >/dev/null
+          else
+            echo "Cannot install jq/uuidgen: no supported package manager found" >&2
+            exit 1
+          fi
+        fi
+        if ! command -v yq >/dev/null 2>&1; then
+          curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.53.6/yq_linux_amd64" -o /tmp/yq
+          chmod +x /tmp/yq
+          as_root mv /tmp/yq /usr/local/bin/yq
+        fi
+
+    - name: Download sushi-wrap.sh
+      shell: bash
+      run: |
+        curl -sSL "${{ inputs.sushi-wrap-url }}" -o /tmp/sushi-wrap.sh
+        chmod +x /tmp/sushi-wrap.sh
+
+    - name: Run sushi-wrap.sh
+      shell: bash
+      env:
+        ACCEPTED_DOWNLOAD_CONDITIONS: ${{ inputs.accepted-download-conditions }}
+        SUSHI_COMMAND: ${{ inputs.sushi-command }}
+      run: |
+        cd "${{ inputs.dir }}"
+        /tmp/sushi-wrap.sh

--- a/.github/workflows/complieswith-export.yml
+++ b/.github/workflows/complieswith-export.yml
@@ -42,7 +42,12 @@ jobs:
         run: node scripts/complieswith/uncomment-inserts.js
 
       - name: Run SUSHI
-        run: npx fsh-sushi Resources/ -s
+        uses: ./.github/actions/run-sushi-with-zts
+        with:
+          dir: Resources
+          accepted-download-conditions: ${{ vars.ZTS_ACCEPTED_DOWNLOAD_CONDITIONS }}
+          # this job has no global "sushi" binary, unlike the IG Publisher container image
+          sushi-command: npx fsh-sushi . -s
 
       - name: Filter validation targets
         run: node scripts/complieswith/filter-validation-targets.js

--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -86,10 +86,13 @@ jobs:
           ls -la /github/home/.fhir/packages/ | head -20
           echo "==================================="
 
-      # Convert shared FSH inputs into FHIR resources once per workflow
+      # Convert shared FSH inputs into FHIR resources once per workflow.
+      # Uses gematik's sushi-wrap.sh to fetch ZTS-only packages first (PTDATA-2315).
       - name: Run SUSHI
-        run: |
-          sushi ${{ env.SUSHI_INPUT_DIR }}
+        uses: ./.github/actions/run-sushi-with-zts
+        with:
+          dir: ${{ env.SUSHI_INPUT_DIR }}
+          accepted-download-conditions: ${{ vars.ZTS_ACCEPTED_DOWNLOAD_CONDITIONS }}
 
       # Share the generated FSH output with parallel IG build jobs
       - name: Upload FSH Generated Resources
@@ -283,10 +286,12 @@ jobs:
             "${SUSHI_INPUT_DIR}/sushi-config.yaml" \
             "${IG_PUBLISHER_DIR}/sushi-config.yaml"
 
-      # Generate IG-specific ImplementationGuide and menu content
+      # Generate IG-specific ImplementationGuide and menu content.
       - name: Run SUSHI (IG local)
-        run: |
-          sushi ${{ env.IG_PUBLISHER_DIR }}
+        uses: ./.github/actions/run-sushi-with-zts
+        with:
+          dir: ${{ env.IG_PUBLISHER_DIR }}
+          accepted-download-conditions: ${{ vars.ZTS_ACCEPTED_DOWNLOAD_CONDITIONS }}
 
       # Tag the SUSHI output with its IG directory for later artifact copy
       - name: Write IG dir metadata (SUSHI)

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "min": 1,
         "mustSupport": true
       },
@@ -276,7 +276,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Substance_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.code.coding:ask",
@@ -502,7 +506,7 @@
         "id": "AllergyIntolerance.reaction.manifestation",
         "path": "AllergyIntolerance.reaction.manifestation",
         "short": "Manifestation der Reaktion",
-        "comment": "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "mustSupport": true
       },
       {
@@ -533,7 +537,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Manifestation_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.reaction.manifestation.text",

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -106,8 +106,9 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       snomed-ct 1..1 MS and
       ask 0..1 MS and
       atc 0..1 MS
-  * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-ausloesende-Substanz (extensible)
+  * coding[snomed-ct] MS 
   * coding[snomed-ct] only ISiKSnomedCTCoding
+  * coding[snomed-ct] from $KBV_VS_Base_Allergien-ausloesende-Substanz (extensible)
   * coding[ask] MS
   * coding[ask] only ISiKASKCoding
     * system MS
@@ -180,8 +181,9 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       * ^slicing.rules = #open
     * coding contains
         snomed-ct 0..1 MS
-    * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-Manifestation (extensible)
+    * coding[snomed-ct] MS 
     * coding[snomed-ct] only ISiKSnomedCTCoding
+    * coding[snomed-ct] from $KBV_VS_Base_Allergien-Manifestation (extensible)
     * text MS
   * severity MS
     * ^short = "Schweregrad der Reaktion"

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -97,7 +97,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^short = "Benennung der Allergie/Unverträglichkeit"
   * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.
 
-  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
+  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
   * coding MS
     * ^slicing.discriminator.type = #pattern
     * ^slicing.discriminator.path = "system"
@@ -173,7 +173,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^comment = "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen."
   * manifestation MS
     * ^short = "Manifestation der Reaktion"
-    * ^comment = "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
+    * ^comment = "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
     * coding MS
       * ^slicing.discriminator.type = #pattern
       * ^slicing.discriminator.path = "system"

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -97,7 +97,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^short = "Benennung der Allergie/Unverträglichkeit"
   * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.
 
-  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
+  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
   * coding MS
     * ^slicing.discriminator.type = #pattern
     * ^slicing.discriminator.path = "system"
@@ -106,7 +106,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       snomed-ct 1..1 MS and
       ask 0..1 MS and
       atc 0..1 MS
-  * coding[snomed-ct] MS
+  * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-ausloesende-Substanz (extensible)
   * coding[snomed-ct] only ISiKSnomedCTCoding
   * coding[ask] MS
   * coding[ask] only ISiKASKCoding
@@ -173,14 +173,14 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^comment = "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen."
   * manifestation MS
     * ^short = "Manifestation der Reaktion"
-    * ^comment = "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview."
+    * ^comment = "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
     * coding MS
       * ^slicing.discriminator.type = #pattern
       * ^slicing.discriminator.path = "system"
       * ^slicing.rules = #open
     * coding contains
         snomed-ct 0..1 MS
-    * coding[snomed-ct] MS
+    * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-Manifestation (extensible)
     * coding[snomed-ct] only ISiKSnomedCTCoding
     * text MS
   * severity MS

--- a/Resources/input/fsh/_Commons/aliases.fsh
+++ b/Resources/input/fsh/_Commons/aliases.fsh
@@ -61,6 +61,8 @@ Alias: $KBV_VS_Base_Role_Care = https://fhir.kbv.de/ValueSet/KBV_VS_Base_Role_Ca
 Alias: $patient-merge-topic = https://gematik.de/fhir/isik/SubscriptionTopic/patient-merge
 Alias: $vsAllergyIntoleranceClinicalStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical
 Alias: $vsAllergyIntoleranceVerificationStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-verification
+Alias: $KBV_VS_Base_Allergien-ausloesende-Substanz = https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Substance_SNOMED_CT
+Alias: $KBV_VS_Base_Allergien-Manifestation = https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Manifestation_SNOMED_CT
 
 Alias: $imposeProfile = http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile
 Alias: $compliesWithProfile = http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile

--- a/Resources/sushi-config.yaml
+++ b/Resources/sushi-config.yaml
@@ -13,3 +13,4 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "de.gematik.ti": "1.3.1",
     "de.fhir.medication": "1.0.7",
     "de.medizininformatikinitiative.kerndatensatz.base": "2026.0.0",
-    "de.medizininformatikinitiative.kerndatensatz.meta": "2026.0.0"
+    "de.medizininformatikinitiative.kerndatensatz.meta": "2026.0.0",
+    "kbv.all.terminology.allergyintolerance": "1.0.0"
   },
   "devDependencies": {
     "dvmd.kdl.r4": "2025.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bfarm.terminologien.icd10gm": "2024.0.0",
     "bfarm.terminologien.ops": "2024.0.0",
     "hl7.fhir.uv.ips": "2.0.0",
-    "kbv.basis": "1.8.0"
+    "kbv.basis": "1.8.0",
+    "kbv.all.terminology.allergyintolerance": "1.0.0"
   }
 }

--- a/publisher-guides/AMTS/fsh-generated/resources/ImplementationGuide-amts.json
+++ b/publisher-guides/AMTS/fsh-generated/resources/ImplementationGuide-amts.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/AMTS/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "min": 1,
         "mustSupport": true
       },
@@ -276,7 +276,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Substance_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.code.coding:ask",
@@ -502,7 +506,7 @@
         "id": "AllergyIntolerance.reaction.manifestation",
         "path": "AllergyIntolerance.reaction.manifestation",
         "short": "Manifestation der Reaktion",
-        "comment": "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "mustSupport": true
       },
       {
@@ -533,7 +537,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Manifestation_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.reaction.manifestation.text",

--- a/publisher-guides/AMTS/sushi-config.yaml
+++ b/publisher-guides/AMTS/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Basis/fsh-generated/resources/ImplementationGuide-basis.json
+++ b/publisher-guides/Basis/fsh-generated/resources/ImplementationGuide-basis.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -8,6 +8,13 @@ Tags werden folgendermaßen verwendet:
 
 - 'fix' sollte nur verwendet werden für Behebung von **Fehlern** an den (potentiell) normativen Inhalten der Spec (Anforderungen + Profile + CapabilityStatements); Typo fixes werden nicht in die Releasenotes aufgenommen. Hier sollen stets die ggf. betroffenen Ressourcen (bzw. CapabilityStatements, Rollen und Akteure) angegeben werden.
 
+### Version 6.x.y
+
+Datum: tbd.
+
+* `improve`Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit
+
+
 ### Version 6.0.0
 
 Datum: 01.07.2026

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -12,7 +12,7 @@ Tags werden folgendermaßen verwendet:
 
 Datum: tbd.
 
-* `improve`Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit <https://github.com/gematik/spec-ISiK-Basismodul/pull/1312>
+* `improve` Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit <https://github.com/gematik/spec-ISiK-Basismodul/pull/1312>
 
 
 ### Version 6.0.0

--- a/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
+++ b/publisher-guides/Basis/input/pagecontent/ReleaseNotes.md
@@ -12,7 +12,7 @@ Tags werden folgendermaßen verwendet:
 
 Datum: tbd.
 
-* `improve`Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit
+* `improve`Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit <https://github.com/gematik/spec-ISiK-Basismodul/pull/1312>
 
 
 ### Version 6.0.0

--- a/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/publisher-guides/Basis/input/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -243,7 +243,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "min": 1,
         "mustSupport": true
       },
@@ -276,7 +276,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Substance_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.code.coding:ask",
@@ -502,7 +506,7 @@
         "id": "AllergyIntolerance.reaction.manifestation",
         "path": "AllergyIntolerance.reaction.manifestation",
         "short": "Manifestation der Reaktion",
-        "comment": "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet. Dieses ValueSet steht zum Zeitpunkt der Veröffentlichung noch nicht als FHIR-konformes und stabil referenzierbares Artefakt zur Verfügung und wird daher zu einem späteren Zeitpunkt in dieser Form ergänzt. Weitere Informationen finden Sie hier: https://mio.kbv.de/spaces/ALDOK1X0X0/overview.",
+        "comment": "**Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "mustSupport": true
       },
       {
@@ -533,7 +537,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Manifestation_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.reaction.manifestation.text",

--- a/publisher-guides/Basis/sushi-config.yaml
+++ b/publisher-guides/Basis/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Connect/fsh-generated/resources/ImplementationGuide-connect.json
+++ b/publisher-guides/Connect/fsh-generated/resources/ImplementationGuide-connect.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Connect/sushi-config.yaml
+++ b/publisher-guides/Connect/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Dokumentenaustausch/fsh-generated/resources/ImplementationGuide-dokumentenaustausch.json
+++ b/publisher-guides/Dokumentenaustausch/fsh-generated/resources/ImplementationGuide-dokumentenaustausch.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Dokumentenaustausch/sushi-config.yaml
+++ b/publisher-guides/Dokumentenaustausch/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Formular/fsh-generated/resources/ImplementationGuide-formular.json
+++ b/publisher-guides/Formular/fsh-generated/resources/ImplementationGuide-formular.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Formular/sushi-config.yaml
+++ b/publisher-guides/Formular/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/ICU/fsh-generated/resources/ImplementationGuide-icu.json
+++ b/publisher-guides/ICU/fsh-generated/resources/ImplementationGuide-icu.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/ICU/sushi-config.yaml
+++ b/publisher-guides/ICU/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Labor/fsh-generated/resources/ImplementationGuide-labor.json
+++ b/publisher-guides/Labor/fsh-generated/resources/ImplementationGuide-labor.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Labor/sushi-config.yaml
+++ b/publisher-guides/Labor/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Medikation/fsh-generated/resources/ImplementationGuide-medikation.json
+++ b/publisher-guides/Medikation/fsh-generated/resources/ImplementationGuide-medikation.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Medikation/sushi-config.yaml
+++ b/publisher-guides/Medikation/sushi-config.yaml
@@ -26,6 +26,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Organspendeerkennung/fsh-generated/resources/ImplementationGuide-organspendeerkennung.json
+++ b/publisher-guides/Organspendeerkennung/fsh-generated/resources/ImplementationGuide-organspendeerkennung.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Organspendeerkennung/sushi-config.yaml
+++ b/publisher-guides/Organspendeerkennung/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Subscription/fsh-generated/resources/ImplementationGuide-subscription.json
+++ b/publisher-guides/Subscription/fsh-generated/resources/ImplementationGuide-subscription.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Subscription/sushi-config.yaml
+++ b/publisher-guides/Subscription/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Terminplanung/fsh-generated/resources/ImplementationGuide-terminplanung.json
+++ b/publisher-guides/Terminplanung/fsh-generated/resources/ImplementationGuide-terminplanung.json
@@ -84,6 +84,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Terminplanung/sushi-config.yaml
+++ b/publisher-guides/Terminplanung/sushi-config.yaml
@@ -25,6 +25,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/publisher-guides/Vitalparameter/fsh-generated/resources/ImplementationGuide-vitalparameter.json
+++ b/publisher-guides/Vitalparameter/fsh-generated/resources/ImplementationGuide-vitalparameter.json
@@ -85,6 +85,12 @@
       "version": "1.0.7",
       "uri": "http://ig.fhir.de/igs/medication/ImplementationGuide/de.fhir.medication",
       "id": "de_fhir_medication"
+    },
+    {
+      "packageId": "kbv.all.terminology.allergyintolerance",
+      "version": "1.0.0",
+      "uri": "http://fhir.org/packages/kbv.all.terminology.allergyintolerance/ImplementationGuide/kbv.all.terminology.allergyintolerance",
+      "id": "kbv_all_terminology_allergyintolerance"
     }
   ],
   "definition": {

--- a/publisher-guides/Vitalparameter/sushi-config.yaml
+++ b/publisher-guides/Vitalparameter/sushi-config.yaml
@@ -26,6 +26,7 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.gematik.ti: 1.3.1
   de.fhir.medication: 1.0.7
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
 pages:
   index.md:

--- a/scripts/ig-publisher/README.md
+++ b/scripts/ig-publisher/README.md
@@ -79,3 +79,16 @@ Deletes the temporary `fhir-packages` artifact after the workflow run.
 
 Resolves the previous successful workflow run head SHA on the current branch and
 exposes it as `last_success_sha` output for later change detection.
+
+## ZTS packages (kbv.all.terminology.*)
+
+Fetching FHIR packages only available via the BfArM Zentraler
+Terminologieserver (ZTS) is done by the composite
+action [`.github/actions/run-sushi-with-zts`](../../.github/actions/run-sushi-with-zts/action.yml),
+used by `ig-publisher.yml` in place of a plain
+`sushi`/`npx fsh-sushi` call. See the action's own inputs for
+configuration (in particular the `ZTS_ACCEPTED_DOWNLOAD_CONDITIONS` repository
+Actions variable, without which SUSHI cannot resolve ZTS-only packages such as
+`kbv.all.terminology.allergyintolerance`).
+- `sushi-wrap.sh` is fetched fresh on every run instead of vendored into this
+  repo, so upstream fixes from gematik apply automatically.


### PR DESCRIPTION
This pull request primarily integrates official allergy-related ValueSets from the central terminology server into the `ISiKAllergieUnvertraeglichkeit` profile, updates documentation accordingly, and adds the required dependencies and aliases. These changes ensure better alignment with standardized terminologies and improve the extensibility and completeness of the allergy and intolerance data model.

**Integration of allergy-related ValueSets:**

* The `ISiKAllergieUnvertraeglichkeit.fsh` profile now references the official KBV ValueSets for `auslösende Substanz` and `Allergiemanifestationen` using the extensible binding, and updates related comments to reflect their inclusion and the rationale for extensibility. [[1]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L100-R100) [[2]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L109-R109) [[3]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L176-R183)

**Dependency and alias updates:**

* Added the `kbv.all.terminology.allergyintolerance` dependency to both `Resources/sushi-config.yaml` and `package.json` to ensure the ValueSets are available in the build. [[1]](diffhunk://#diff-a3204f21b2683a9429c1a6dd8d3b7839739849a0331a386ce6f3424cb64553f6R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R19)
* Introduced new aliases for the referenced KBV ValueSets in `_Commons/aliases.fsh`.

**Documentation:**

* Added a release note entry describing the integration of the allergy ValueSets into the `ISiKAllergieUnvertraeglichkeit` profile.