### PR TITLE
init allergy vs

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKAllergieUnvertraeglichkeit.json
@@ -113,7 +113,7 @@
         "id": "AllergyIntolerance.code",
         "path": "AllergyIntolerance.code",
         "short": "Benennung der Allergie/Unverträglichkeit",
-        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.",
+        "comment": "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und diese ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden.",
         "min": 1,
         "mustSupport": true
       },
@@ -146,7 +146,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "preferred",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Substance_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.code.coding:ask",
@@ -400,7 +404,7 @@
         "id": "AllergyIntolerance.reaction",
         "path": "AllergyIntolerance.reaction",
         "short": "Unerwünschte Reaktion",
-        "comment": "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen.",
+        "comment": "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen.\n\n  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann und die Änderung nach möglichem Zertifizierungs-Beginn erfolgt, ist es mit 'preferred' eingebunden.",
         "mustSupport": true
       },
       {
@@ -437,7 +441,11 @@
             ]
           }
         ],
-        "mustSupport": true
+        "mustSupport": true,
+        "binding": {
+          "strength": "preferred",
+          "valueSet": "https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Manifestation_SNOMED_CT"
+        }
       },
       {
         "id": "AllergyIntolerance.reaction.manifestation.text",

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -67,8 +67,9 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       snomed-ct 1..1 MS and
       ask 0..1 MS and
       atc 0..1 MS
-  * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-ausloesende-Substanz (preferred)
+  * coding[snomed-ct] MS 
   * coding[snomed-ct] only ISiKSnomedCTCoding
+  * coding[snomed-ct] from $KBV_VS_Base_Allergien-ausloesende-Substanz (preferred)
   * coding[ask] MS
   * coding[ask] only CodingASK
     * system MS
@@ -142,8 +143,9 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       * ^slicing.rules = #open
     * coding contains
         snomed-ct 0..1 MS
-    * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-Manifestation (preferred)
+    * coding[snomed-ct] MS 
     * coding[snomed-ct] only ISiKSnomedCTCoding
+    * coding[snomed-ct] from $KBV_VS_Base_Allergien-Manifestation (preferred)
     * text MS
   * severity MS
     * ^short = "Schweregrad der Reaktion"

--- a/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
+++ b/Resources/input/fsh/Basis/ISiKAllergieUnvertraeglichkeit.fsh
@@ -56,7 +56,9 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * ^comment = "**Begründung MS:** Die Kritikalität beschreibt das erwartete Risiko bei erneuter Exposition und dient der Priorisierung von Warnhinweisen."
 * code 1.. MS
   * ^short = "Benennung der Allergie/Unverträglichkeit"
-  * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen."
+  * ^comment = "**Begründung Pflichtfeld:** Nur mit einer codierten oder textuell benannten Auslösersubstanz lässt sich die Allergie klinisch interpretieren und für Interaktionsprüfungen nutzen.
+
+  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `auslösende Substanz` im deutschen Gesundheitswesen erarbeitet und diese ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann, ist es mit 'extensible' eingebunden."
   * coding MS
     * ^slicing.discriminator.type = #pattern
     * ^slicing.discriminator.path = "system"
@@ -65,7 +67,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       snomed-ct 1..1 MS and
       ask 0..1 MS and
       atc 0..1 MS
-  * coding[snomed-ct] MS
+  * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-ausloesende-Substanz (preferred)
   * coding[snomed-ct] only ISiKSnomedCTCoding
   * coding[ask] MS
   * coding[ask] only CodingASK
@@ -129,7 +131,9 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
   * text MS
 * reaction MS
   * ^short = "Unerwünschte Reaktion"
-  * ^comment = "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen."
+  * ^comment = "**Begründung MS:** Die beobachtete Reaktion ist für die klinische Bewertung der Gefährdung essenziell und Grundlage für Entscheidungshilfen.
+
+  **Hinweis und Hintergrund:** Die mio42 GmbH hat gemeinsam mit dem BfArM ein ValueSet für die `Allergiemanifestationen` im deutschen Gesundheitswesen erarbeitet und dies ist an dieser Stelle eingebunden worden. Da die Vollständigkeit des ValueSets im ISiK-Kontext nicht garantiert werden kann und die Änderung nach möglichem Zertifizierungs-Beginn erfolgt, ist es mit 'preferred' eingebunden."
   * manifestation MS
     * ^short = "Manifestation der Reaktion"
     * coding MS
@@ -138,7 +142,7 @@ Bitte auch beachten, dass verificationStatus bei Condition derzeit KEIN MS-Flag 
       * ^slicing.rules = #open
     * coding contains
         snomed-ct 0..1 MS
-    * coding[snomed-ct] MS
+    * coding[snomed-ct] MS from $KBV_VS_Base_Allergien-Manifestation (preferred)
     * coding[snomed-ct] only ISiKSnomedCTCoding
     * text MS
   * severity MS

--- a/Resources/input/fsh/_Commons/aliases.fsh
+++ b/Resources/input/fsh/_Commons/aliases.fsh
@@ -58,6 +58,8 @@ Alias: $kvnr30 = http://fhir.de/sid/gkv/kvnr-30
 Alias: $patient-merge-topic = https://gematik.de/fhir/isik/SubscriptionTopic/patient-merge
 Alias: $vsAllergyIntoleranceClinicalStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical
 Alias: $vsAllergyIntoleranceVerificationStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-verification
+Alias: $KBV_VS_Base_Allergien-ausloesende-Substanz = https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Substance_SNOMED_CT
+Alias: $KBV_VS_Base_Allergien-Manifestation = https://fhir.kbv.de/ValueSet/KBV_VS_AllergyIntolerance_Manifestation_SNOMED_CT
 
 Alias: $imposeProfile = http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile
 Alias: $GEM_PR_KIM_AdressIdentifier = https://gematik.de/fhir/atf/StructureDefinition/identifier-address-kim

--- a/Resources/sushi-config.yaml
+++ b/Resources/sushi-config.yaml
@@ -13,5 +13,6 @@ dependencies:
   de.gematik.terminology: 1.0.6
   de.fhir.medication: 1.0.4
   de.gematik.ti: 1.1.1
+  kbv.all.terminology.allergyintolerance: 1.0.0
 
   

--- a/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
@@ -18,6 +18,13 @@ Die Tags werden folgendermaßen verwendet:
 
 - 'fix' sollte nur verwendet werden für Behebung von **Fehlern** an den (potentiell) normativen Inhalten der Spec (Anforderungen + Profile + CpS); Typo fixes werden nicht in die Releasenotes aufgenommen.
 
+
+## Version 5.x.y
+
+Datum: tbd.
+
+* `improve` Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit
+
 ## Version 5.1.3
 
 Datum: 20.07.2026

--- a/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
+++ b/guides/Basis-5/Einfuehrung/ReleaseNotes.page.md
@@ -23,7 +23,7 @@ Die Tags werden folgendermaßen verwendet:
 
 Datum: tbd.
 
-* `improve` Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit
+* `improve` Einbinden der Allergie-ValueSets nach Publikation auf Zentralem Terminologie-Server im Profil ISiKAllergieUnvertraeglichkeit https://github.com/gematik/spec-ISiK-Basismodul/pull/1313
 
 ## Version 5.1.3
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "hl7.fhir.uv.sdc": "4.0.0-ballot",
     "de.gematik.terminology": "1.0.6",
     "de.fhir.medication": "1.0.4",
-    "de.gematik.ti": "1.1.1"
+    "de.gematik.ti": "1.1.1",
+    "kbv.all.terminology.allergyintolerance": "1.0.0"
   },
   "devDependencies": {
     "dvmd.kdl.r4": "2025.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dvmd.kdl.r4": "2025.0.1",
     "bfarm.terminologien.icd10gm": "2024.0.0",
     "bfarm.terminologien.ops": "2024.0.0",
-    "hl7.fhir.uv.ips": "2.0.0"
+    "hl7.fhir.uv.ips": "2.0.0",
+    "kbv.all.terminology.allergyintolerance": "1.0.0"
   }
 }


### PR DESCRIPTION
This pull request updates the ISiK Allergy/Intolerance profile to integrate newly published allergy-related ValueSets from the central terminology server, and documents these changes. It also updates dependencies to include the relevant terminology package. The most important changes are:

**Integration of Allergy-Related ValueSets:**

* The `code.coding[snomed-ct]` element in `ISiKAllergieUnvertraeglichkeit.fsh` is now bound to the `$KBV_VS_Base_Allergien-ausloesende-Substanz` ValueSet with a binding strength of 'preferred', and a detailed comment explains the rationale and context for this integration. [[1]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L59-R61) [[2]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L68-R70)
* The `reaction.manifestation.coding[snomed-ct]` element is now bound to `$KBV_VS_Base_Allergien-Manifestation` with a 'preferred' binding, and an explanatory comment is added regarding the background and limitations. [[1]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L132-R136) [[2]](diffhunk://#diff-98b21f91633adac4ae12f18e1dd50d45908b0d15db661eb04dd5ff2d9553dfe4L141-R145)

**Documentation and Release Notes:**

* Added a new release notes entry for version 5.x.y describing the integration of the allergy ValueSets into the ISiKAllergieUnvertraeglichkeit profile.

**Dependency Updates:**

* Added `kbv.all.terminology.allergyintolerance` version 1.0.0 to both `sushi-config.yaml` and `package.json` to ensure the new ValueSets are available for use. [[1]](diffhunk://#diff-a3204f21b2683a9429c1a6dd8d3b7839739849a0331a386ce6f3424cb64553f6R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R16)
