### PR TITLE
Update parameters handling for Stufe 5 branches

### DIFF
--- a/.github/workflows/TC-version-update.yml
+++ b/.github/workflows/TC-version-update.yml
@@ -7,7 +7,15 @@ on:
       branches:
         - 'TC-6*'
         - 'TC_6*'
+        - 'TC-5*'
+        - 'TC_5*'
 
+env:
+    # Comma-separated list of IG name keywords excluded from the automatic version update.
+    # Matched case-insensitively as a substring against the IG folder name under guides/
+    # (e.g. "formular" matches guides/Formulare-5, "subscription" matches guides/Subscriptions-5).
+    # Maintain this list here to add/remove excluded IGs.
+    EXCLUDED_IGS: 'formular,subscription'
 
 # setup python and run script 
 jobs:
@@ -28,7 +36,7 @@ jobs:
               pip install pyyaml
     
           - name: execute py script # run main.py
-            run: python ./scripts/release_publish.py -b
+            run: python ./scripts/release_publish.py -b --exclude-igs "$EXCLUDED_IGS"
 
           - name: Add & Commit
             uses: EndBug/add-and-commit@v9

--- a/.github/workflows/TC-version-update.yml
+++ b/.github/workflows/TC-version-update.yml
@@ -12,10 +12,11 @@ on:
 
 env:
     # Comma-separated list of IG name keywords excluded from the automatic version update.
+    # Only applies to Stufe-5 branches (TC-5*/TC_5*); Stufe-6 branches (TC-6*/TC_6*) get an empty list.
     # Matched case-insensitively as a substring against the IG folder name under guides/
     # (e.g. "formular" matches guides/Formulare-5, "subscription" matches guides/Subscriptions-5).
     # Maintain this list here to add/remove excluded IGs.
-    EXCLUDED_IGS: 'formular,subscription'
+    EXCLUDED_IGS: ${{ (startsWith(github.ref_name, 'TC-5') || startsWith(github.ref_name, 'TC_5')) && 'formular,subscription' || '' }}
 
 # setup python and run script 
 jobs:

--- a/scripts/excluded_igs.yaml
+++ b/scripts/excluded_igs.yaml
@@ -1,8 +1,10 @@
 # Local default exclusion list used by release_publish.py when --exclude-igs is not passed on the command line.
+# Keyed by stufe (as parsed from the branch name TC-<stufe>*/TC_<stufe>*, or via --stufe).
 # Entries are matched case-insensitively as a substring against the IG folder name under guides/
 # (e.g. "formular" matches "guides/Formulare-5", "subscription" matches "guides/Subscriptions-5").
 # The GitHub Action workflow maintains its own list and passes it explicitly via --exclude-igs,
 # overriding this file when running in CI.
 excluded_igs:
-  - formular
-  - subscription
+  "5":
+    - formular
+    - subscription

--- a/scripts/excluded_igs.yaml
+++ b/scripts/excluded_igs.yaml
@@ -1,0 +1,8 @@
+# Local default exclusion list used by release_publish.py when --exclude-igs is not passed on the command line.
+# Entries are matched case-insensitively as a substring against the IG folder name under guides/
+# (e.g. "formular" matches "guides/Formulare-5", "subscription" matches "guides/Subscriptions-5").
+# The GitHub Action workflow maintains its own list and passes it explicitly via --exclude-igs,
+# overriding this file when running in CI.
+excluded_igs:
+  - formular
+  - subscription

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -154,23 +154,35 @@ def get_guide_name_from_path(location: str):
     return None
 
 
-def load_excluded_igs(cli_value: str, exclude_config_path: str, stufe: str = None) -> list:
-    if cli_value:
-        return [ig.strip() for ig in cli_value.split(',') if ig.strip()]
-
-    git_branch = get_new_release_version_from_branch_name()
-    effective_stufe = stufe or get_stufe_from_branch(git_branch)
-    # the local default exclusion list only applies when the current branch matches the given stufe (TC-<stufe>*/TC_<stufe>*)
-    if not effective_stufe or not is_branch_for_stufe(git_branch, effective_stufe):
-        return []
-
-    if not os.path.exists(exclude_config_path):
+def read_local_excluded_igs_for_stufe(exclude_config_path: str, stufe: str) -> list:
+    if not stufe or not os.path.exists(exclude_config_path):
         return []
 
     with open(exclude_config_path, 'r', encoding='utf-8') as exclude_config_file:
         exclude_config = yaml.safe_load(exclude_config_file) or {}
     excludes_by_stufe = {str(key): value for key, value in (exclude_config.get('excluded_igs') or {}).items()}
-    return [ig.strip() for ig in excludes_by_stufe.get(str(effective_stufe), []) if ig and ig.strip()]
+    return [ig.strip() for ig in excludes_by_stufe.get(str(stufe), []) if ig and ig.strip()]
+
+
+def load_excluded_igs(cli_value: str, exclude_config_path: str, stufe: str = None) -> list:
+    git_branch = get_new_release_version_from_branch_name()
+    effective_stufe = stufe or get_stufe_from_branch(git_branch)
+    # the local config only applies/is comparable when the current branch matches the given stufe (TC-<stufe>*/TC_<stufe>*)
+    branch_matches_stufe = bool(effective_stufe) and is_branch_for_stufe(git_branch, effective_stufe)
+
+    if cli_value:
+        cli_igs = [ig.strip() for ig in cli_value.split(',') if ig.strip()]
+        if branch_matches_stufe:
+            local_igs = read_local_excluded_igs_for_stufe(exclude_config_path, effective_stufe)
+            if set(ig.lower() for ig in cli_igs) != set(ig.lower() for ig in local_igs):
+                print(f"Warning: Mismatch between parameter input and local config for stufe '{effective_stufe}': "
+                      f"parameter=[{', '.join(cli_igs)}], local config=[{', '.join(local_igs)}]. "
+                      f"Using the parameter value; please update '{exclude_config_path}' to keep them in sync.")
+        return cli_igs
+
+    if not branch_matches_stufe:
+        return []
+    return read_local_excluded_igs_for_stufe(exclude_config_path, effective_stufe)
 
 
 def filter_excluded_igs(files: list, excluded_igs: list) -> list:

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -35,6 +35,15 @@ def modify_TC_branch_name_to_version(git_branch):
         version = git_branch.lstrip('TC_')
     return version
 
+
+def get_stufe_from_branch(git_branch: str):
+    match = re.match(r'^TC[-_](\d+)', git_branch)
+    return match.group(1) if match else None
+
+
+def is_branch_for_stufe(git_branch: str, stufe: str) -> bool:
+    return git_branch.startswith(f'TC-{stufe}') or git_branch.startswith(f'TC_{stufe}')
+
 def create_files_to_update_list(config):
     files_to_update = []
     for filename, replacements in config.items():
@@ -145,14 +154,23 @@ def get_guide_name_from_path(location: str):
     return None
 
 
-def load_excluded_igs(cli_value: str, exclude_config_path: str) -> list:
+def load_excluded_igs(cli_value: str, exclude_config_path: str, stufe: str = None) -> list:
     if cli_value:
         return [ig.strip() for ig in cli_value.split(',') if ig.strip()]
-    if os.path.exists(exclude_config_path):
-        with open(exclude_config_path, 'r', encoding='utf-8') as exclude_config_file:
-            exclude_config = yaml.safe_load(exclude_config_file) or {}
-        return [ig.strip() for ig in exclude_config.get('excluded_igs', []) if ig and ig.strip()]
-    return []
+
+    git_branch = get_new_release_version_from_branch_name()
+    effective_stufe = stufe or get_stufe_from_branch(git_branch)
+    # the local default exclusion list only applies when the current branch matches the given stufe (TC-<stufe>*/TC_<stufe>*)
+    if not effective_stufe or not is_branch_for_stufe(git_branch, effective_stufe):
+        return []
+
+    if not os.path.exists(exclude_config_path):
+        return []
+
+    with open(exclude_config_path, 'r', encoding='utf-8') as exclude_config_file:
+        exclude_config = yaml.safe_load(exclude_config_file) or {}
+    excludes_by_stufe = {str(key): value for key, value in (exclude_config.get('excluded_igs') or {}).items()}
+    return [ig.strip() for ig in excludes_by_stufe.get(str(effective_stufe), []) if ig and ig.strip()]
 
 
 def filter_excluded_igs(files: list, excluded_igs: list) -> list:
@@ -206,7 +224,9 @@ def main():
     parser.add_argument('-x', '--exclude-igs', type=str, default=None,
                          help='comma-separated list of IG name keywords to exclude from the version update, e.g. "formular,subscription"')
     parser.add_argument('--exclude-config', type=str, default='excluded_igs.yaml',
-                         help='path (relative to this script) to a local yaml config providing an "excluded_igs" list, used when --exclude-igs is not given')
+                         help='path (relative to this script) to a local yaml config providing per-stufe "excluded_igs" lists, used when --exclude-igs is not given')
+    parser.add_argument('-s', '--stufe', type=str, default=None,
+                         help='stufe (e.g. "5") whose excluded_igs entry from --exclude-config should apply; defaults to the stufe parsed from the current branch name (TC-<stufe>*/TC_<stufe>*)')
     args = parser.parse_args()
 
     if args.version:
@@ -229,7 +249,7 @@ def main():
     located_files = locate_files_in_current_project(files_to_update)
 
     exclude_config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), args.exclude_config)
-    excluded_igs = load_excluded_igs(args.exclude_igs, exclude_config_path)
+    excluded_igs = load_excluded_igs(args.exclude_igs, exclude_config_path, args.stufe)
     located_files = filter_excluded_igs(located_files, excluded_igs)
 
     replace_content_in_files(located_files, new_release_version, custom_date)

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -134,6 +134,46 @@ def replace_date_in_file(file: FileTypeCombinationToUpdate, new_date: datetime):
     with open(file.location, 'w', encoding='utf-8') as output_file:  # Specify encoding
         output_file.write(input_text)
 
+def get_guide_name_from_path(location: str):
+    # Returns the IG folder name directly under "guides/", e.g. "Formulare-5", or None if not applicable
+    normalized = location.replace('\\', '/')
+    parts = [part for part in normalized.split('/') if part]
+    if 'guides' in parts:
+        index = parts.index('guides')
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    return None
+
+
+def load_excluded_igs(cli_value: str, exclude_config_path: str) -> list:
+    if cli_value:
+        return [ig.strip() for ig in cli_value.split(',') if ig.strip()]
+    if os.path.exists(exclude_config_path):
+        with open(exclude_config_path, 'r', encoding='utf-8') as exclude_config_file:
+            exclude_config = yaml.safe_load(exclude_config_file) or {}
+        return [ig.strip() for ig in exclude_config.get('excluded_igs', []) if ig and ig.strip()]
+    return []
+
+
+def filter_excluded_igs(files: list, excluded_igs: list) -> list:
+    if not excluded_igs:
+        return files
+
+    filtered_files = []
+    skipped_guides = set()
+    for file in files:
+        guide_name = get_guide_name_from_path(file.location)
+        if guide_name and any(ig.lower() in guide_name.lower() for ig in excluded_igs):
+            skipped_guides.add(guide_name)
+            continue
+        filtered_files.append(file)
+
+    if skipped_guides:
+        print(f"Info: Skipped version update for excluded IGs: {', '.join(sorted(skipped_guides))}.")
+
+    return filtered_files
+
+
 def output_commit_messages_since_last_release():
     latest_release_tag = get_latest_release_tag()
     if latest_release_tag is None:
@@ -163,6 +203,10 @@ def main():
     parser.add_argument('-d', '--date', type=str, help='specify custom date for release')
     parser.add_argument('-c', '--config', type=str, default='config.yaml', help='specify config file')
     parser.add_argument('-o', '--output', action='store_true', help='output commit messages since last release')
+    parser.add_argument('-x', '--exclude-igs', type=str, default=None,
+                         help='comma-separated list of IG name keywords to exclude from the version update, e.g. "formular,subscription"')
+    parser.add_argument('--exclude-config', type=str, default='excluded_igs.yaml',
+                         help='path (relative to this script) to a local yaml config providing an "excluded_igs" list, used when --exclude-igs is not given')
     args = parser.parse_args()
 
     if args.version:
@@ -183,6 +227,11 @@ def main():
     config = load_config_file(config_file_path)
     files_to_update = create_files_to_update_list(config)
     located_files = locate_files_in_current_project(files_to_update)
+
+    exclude_config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), args.exclude_config)
+    excluded_igs = load_excluded_igs(args.exclude_igs, exclude_config_path)
+    located_files = filter_excluded_igs(located_files, excluded_igs)
+
     replace_content_in_files(located_files, new_release_version, custom_date)
 
     if args.output:


### PR DESCRIPTION
Enhance the handling of parameters in the version update process for Stufe 5 branches, including the addition of an exclusion list for specific IG names. This change improves the flexibility and control over which guides are updated during the release process.

## Description

Re-enables the automatic version update (TC-version-update.yml + `scripts/release_publish.py`) for **Stufe 5** branches and introduces a configurable, per-Stufe exclusion list so that specific IGs (currently `formular` and `subscription`) are skipped by the automatic version bump.

Changes:
- `.github/workflows/TC-version-update.yml`
  - Trigger extended with `TC-5*`/`TC_5*` push branches (previously only `TC-6*`/`TC_6*`, which silently disabled the process for Stufe 5 — see [#1291 (comment)](https://github.com/gematik/spec-ISiK-Basismodul/pull/1291#discussion_r3601998267)).
  - New `EXCLUDED_IGS` env var, computed via `github.ref_name` (`startsWith(..., 'TC-5') || startsWith(..., 'TC_5')`) so the exclusion list is **only** applied for Stufe‑5 pushes; Stufe‑6 pushes get an empty list and are unaffected.
  - Passed to the script via `--exclude-igs "$EXCLUDED_IGS"`.
- `scripts/release_publish.py`
  - New `-x`/`--exclude-igs` CLI argument (comma-separated IG keywords, explicit override, works regardless of branch).
  - New `-s`/`--stufe` CLI argument plus `get_stufe_from_branch()` / `is_branch_for_stufe()` helpers — generic "stufe" concept instead of a hardcoded Stufe‑5 check.
  - New `--exclude-config` argument (default `scripts/excluded_igs.yaml`) for local runs: the file is keyed by stufe and is only applied if the current branch actually matches `TC-<stufe>*`/`TC_<stufe>*`.
  - `get_guide_name_from_path()` / `filter_excluded_igs()` restrict matching to files under `guides/<IG>-5/...`; global files (`package.json`, `Resources/sushi-config.yaml`, `ruleset.fsh`, `ImplementationGuide/markdown/Einfuehrung.md`) are always updated regardless of the exclusion list.
  - Skipped IGs are logged: `Info: Skipped version update for excluded IGs: <names>.`
- `scripts/excluded_igs.yaml` (new): local default exclusion list, keyed by stufe:
  ```yaml
  excluded_igs:
    "5":
      - formular
      - subscription
  ```

## Motivation and Context

Original ticket: automatic version upgrade for Stufe 5 was deactivated because the version-bump script updated **all** IGs indiscriminately, repeatedly overwriting manually-fixed version/release-note entries for `Formulare` and `Subscriptions` (see [#1291](https://github.com/gematik/spec-ISiK-Basismodul/pull/1291#discussion_r3601998267)). This PR reactivates the process for Stufe 5 while excluding those two IGs, and generalizes the exclusion mechanism (via a `stufe` parameter) so it can be reused/extended later for Stufe 6 or additional IGs without code changes.

## How has this been tested?

### Checklist
- [x] Script tested locally for both the exclusion and non-exclusion code paths.
- [x] No unintended file changes committed (verified via `git status` after each test run).
- [x] Workflow run verified in CI on a real `TC-5*` push to `main-stufe-5` -  push/merge to a `TC-5*` (or `TC_5*`) branch targeting `main-stufe-5` and confirm the Action run excludes `formular`/`subscription`, logs the skipped IGs, and commits version changes for all other IGs only.
    - [x] https://github.com/gematik/spec-ISiK-Basismodul/pull/1316 
    - [x] test für übergabe nur mittels action (ohne lokale config): https://github.com/gematik/spec-ISiK-Basismodul/pull/1317/changes 

### Testing in detail

All tests were run locally against this branch with `python .\scripts\release_publish.py ...`, followed by `git status --porcelain` to inspect affected files, and reverted afterwards with `git checkout -- <files>` (no test commits were made).

1. **Baseline run, exclusion active (CLI override, works on any branch):**
   ```
   python .\scripts\release_publish.py -v 9.9.9-test --exclude-igs "formular,subscription"
   ```
   Output: `Info: Skipped version update for excluded IGs: Formulare-5, Subscriptions-5.`
   `git status --porcelain` confirmed **all** other IGs + global files (`package.json`, `Resources/sushi-config.yaml`, `ruleset.fsh`, `ImplementationGuide/markdown/Einfuehrung.md`, all other `guides/*-5` folders) were updated, and `guides/Formulare-5` / `guides/Subscriptions-5` were **not** touched.

2. **Branch-gate check with explicit `--stufe 5` on a non-matching branch (`main-stufe-5`, which is not `TC-5*`/`TC_5*`):**
   ```
   python .\scripts\release_publish.py -v 9.9.9-test --stufe 5
   ```
   Result: exclusion was **not** applied (`Formulare-5`/`Subscriptions-5` were updated too) — confirms the local `excluded_igs.yaml` default only kicks in when the branch actually matches the given/detected stufe, not just because `--stufe` was passed.

3. **End-to-end local-config path on a real matching branch:**
   Created a temporary local branch `TC-5-test-local-verification` and ran:
   ```
   python .\scripts\release_publish.py -v 9.9.9-test
   ```
   (no `--exclude-igs`/`--stufe` args at all)
   Output: `Info: Skipped version update for excluded IGs: Formulare-5, Subscriptions-5.`
   Confirms `scripts/excluded_igs.yaml`'s `"5"` entry is picked up automatically once the branch name matches `TC-5*`.

4. All test runs' file changes were reverted via `git checkout --`; the temporary branch was deleted afterwards. Working tree only contains the intended changes to `.github/workflows/TC-version-update.yml`, `scripts/release_publish.py`, and `scripts/excluded_igs.yaml`.

*(Note: the GitHub Actions workflow itself, including the `github.ref_name`-based `EXCLUDED_IGS` computation, has not yet been run in CI — see Next Steps.)*





