### PR TITLE
Stufe-6/all/fix/ptdata-2346-fix-complies-with-extension

### DIFF
--- a/.github/workflows/complieswith-export.yml
+++ b/.github/workflows/complieswith-export.yml
@@ -18,7 +18,7 @@ env:
     hl7.fhir.eu.hdr#current
     hl7.fhir.eu.base#current
     hl7.fhir.eu.laboratory#current
-    hl7.fhir.eu.mpd#1.0.0
+    hl7.fhir.eu.mpd#current
     de.medizininformatikinitiative.kerndatensatz.base#2026.0.0
     kbv.basis#1.8.0
     de.gevko.emdaf#1.3.0

--- a/.github/workflows/complieswith-export.yml
+++ b/.github/workflows/complieswith-export.yml
@@ -18,7 +18,7 @@ env:
     hl7.fhir.eu.hdr#current
     hl7.fhir.eu.base#current
     hl7.fhir.eu.laboratory#current
-    hl7.fhir.eu.mpd#current
+    hl7.fhir.eu.mpd#1.0.0
     de.medizininformatikinitiative.kerndatensatz.base#2026.0.0
     kbv.basis#1.8.0
     de.gevko.emdaf#1.3.0


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by specifying an exact version for a dependency.

- Updated the `hl7.fhir.eu.mpd` dependency version from `current` to `1.0.0` in the `.github/workflows/complieswith-export.yml` workflow file.